### PR TITLE
ci: fix release/CI image builds (drop flaky metadata-action)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,15 +73,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.image }}
-          tags: |
-            type=raw,value=latest
-            type=raw,value=main
-            type=sha,prefix=
+      # Compute tags in shell (not docker/metadata-action, whose API-backed
+      # label enrichment intermittently fails with "Bad credentials").
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          img="${REGISTRY}/${ORG}/${{ matrix.image }}"
+          {
+            echo "tags<<EOF"
+            echo "${img}:latest"
+            echo "${img}:main"
+            echo "${img}:sha-${GITHUB_SHA::7}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -89,8 +94,10 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,15 +49,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.image }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+      # Compute tags in shell rather than docker/metadata-action: that action
+      # makes a GitHub API call to enrich OCI labels which intermittently
+      # returns "Bad credentials" and hard-fails the build. Shell is
+      # deterministic and needs no API.
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          img="${REGISTRY}/${ORG}/${{ matrix.image }}"
+          v="${GITHUB_REF_NAME#v}"
+          {
+            echo "tags<<EOF"
+            echo "${img}:${v}"
+            # major.minor only for a clean (non-prerelease) semver tag
+            if [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo "${img}:${v%.*}"; fi
+            echo "${img}:sha-${GITHUB_SHA::7}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -65,8 +74,10 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/runner-images.yaml
+++ b/.github/workflows/runner-images.yaml
@@ -80,14 +80,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ matrix.runner.image }}
-          tags: |
-            type=raw,value=latest
-            type=sha,prefix=
+      # Compute tags in shell (not docker/metadata-action, whose API-backed
+      # label enrichment intermittently fails with "Bad credentials").
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          img="${REGISTRY}/${{ matrix.runner.image }}"
+          {
+            echo "tags<<EOF"
+            echo "${img}:latest"
+            echo "${img}:sha-${GITHUB_SHA::7}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -96,8 +101,10 @@ jobs:
           file: ${{ matrix.runner.dockerfile }}
           # PR: build-only validation. Push on merge to main / manual dispatch.
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.runner.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.runner.name }}
           # PR: amd64 only (fast). main/dispatch: full multi-arch.


### PR DESCRIPTION
## Summary

The **v0.3.1 release run failed** at `docker/metadata-action` with
`Bad credentials - https://docs.github.com/rest`, and a CI-on-main run lost
1 of 4 image builds the same way. The action makes a GitHub API call to enrich
OCI labels that **intermittently returns 401**, and the current `@v6` hard-fails
on it (it was non-fatal when the v0.1.x releases ran in March).

Replace `metadata-action` in all three image-building workflows
(`release.yaml`, `ci.yaml` container job, `runner-images.yaml`) with a
deterministic shell step that derives tags from `GITHUB_REF_NAME` / `GITHUB_SHA`
— **no GitHub API call** — and set `org.opencontainers.image.source/revision`
labels statically.

- Release tags: `:X.Y.Z`, `:X.Y` (clean semver only), `:sha-<short>`.
- CI (main): `:latest`, `:main`, `:sha-<short>`.
- Runner images: `:latest`, `:sha-<short>` (push on main; build-only on PRs).

## After merge — re-run the v0.3.1 release

The failed run published nothing (it died before any image/chart push), so the
`v0.3.1` tag can be safely re-pointed at the fixed commit:

```bash
git tag -f v0.3.1 <merge-commit-on-main> && git push -f origin v0.3.1
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge + re-tag, the Release workflow builds + pushes all nine images and publishes the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)