### PR TITLE
ci: skip build pipeline on docs-only changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    # Only redeploy the site when docs (or this workflow) change — avoids
+    # rebuilding GitHub Pages on pure-code pushes.
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy.yml'
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 


### PR DESCRIPTION
## Problem

Both `ci.yaml` (build/test + container images) and `deploy.yml` (GitHub Pages) trigger on every push to `main` with no path filters. A docs-only change therefore runs the **entire** build/test/container pipeline for nothing — when all that's needed is the Pages redeploy.

`main` has no branch protection / required status checks, so skipping CI on docs-only changes won't leave PRs stuck on "Expected — waiting for status".

## Change

- **`ci.yaml`** — add `paths-ignore` (`docs/**`, root `*.md`) to both the `push` and `pull_request` triggers.
- **`deploy.yml`** — add `paths` (`docs/**` + the workflow file) so the site only redeploys on docs changes, not on pure-code pushes.

| Change set | CI build | Pages deploy |
|---|---|---|
| Docs only (`docs/**`, `*.md`) | ⏭️ skipped | ✅ runs |
| Code only | ✅ runs | ⏭️ skipped |
| Mixed (docs + code) | ✅ runs | ✅ runs |

Note: `*.md` matches only root-level markdown (e.g. `README.md`, `refactor.md`), not nested fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)