### PR TITLE
security: harden auth defaults, agent control API, and production values

### DIFF
--- a/cmd/vibed-agent/main.go
+++ b/cmd/vibed-agent/main.go
@@ -35,6 +35,7 @@ func main() {
 		ControlAddr:  env("VIBED_AGENT_CONTROL_ADDR", ":9000"),
 		Workdir:      env("VIBED_AGENT_WORKDIR", "/workspace"),
 		Token:        os.Getenv("VIBED_AGENT_TOKEN"),
+		RequireAuth:  os.Getenv("VIBED_AGENT_REQUIRE_AUTH") == "true",
 		AppPort:      envInt("VIBED_AGENT_APP_PORT", 8080),
 		LogLines:     envInt("VIBED_AGENT_LOG_LINES", 500),
 		Logger:       logger,

--- a/cmd/vibed-controller/main.go
+++ b/cmd/vibed-controller/main.go
@@ -77,8 +77,8 @@ func main() {
 		"Strict gate: deny claims for slots without a Valid recorded result AND when the warm-pool pod's current ImageID drifts from the validated digest (mutable-tag bypass guard). Default fail-open during the 2-minute warmup.")
 	flag.StringVar(&poolNamespace, "pool-namespace", "vibed-pools",
 		"Namespace where SandboxWarmPool / SandboxTemplate live (matches templates/*/template.yaml).")
-	flag.StringVar(&agentToken, "agent-token", "",
-		"Bearer token vibed-agent expects on /healthz. Empty = no auth header sent.")
+	flag.StringVar(&agentToken, "agent-token", os.Getenv("VIBED_AGENT_TOKEN"),
+		"Bearer token sent to vibed-agent's control API. Defaults to $VIBED_AGENT_TOKEN (wired from the vibed-agent-token Secret). Empty = no auth header sent.")
 	flag.IntVar(&workerdReplicas, "workerd-replicas", 0,
 		"workerd StatefulSet size. 0 disables the fast lane (workerd apps fail to deploy).")
 	flag.IntVar(&workerdControlPort, "workerd-control-port", 9200,

--- a/deploy/helm/vibed/templates/egress-authz.yaml
+++ b/deploy/helm/vibed/templates/egress-authz.yaml
@@ -78,10 +78,22 @@ spec:
               deploys never leave Starting.
             */}}
             {{- $systemHosts := .Values.egressControl.systemHosts | default list }}
-            {{- if eq (.Values.config.storage.tarball.backend | default "served") "served" }}
+            {{- $backend := .Values.config.storage.tarball.backend | default "served" }}
+            {{- if eq $backend "served" }}
               {{- $servedHost := printf "%s.%s.svc.cluster.local" (include "vibed.fullname" .) .Release.Namespace }}
               {{- if not (has $servedHost $systemHosts) }}
                 {{- $systemHosts = append $systemHosts $servedHost }}
+              {{- end }}
+            {{- else if eq $backend "s3" }}
+              {{- /* The agent pulls the presigned source tarball through the same
+                     HTTP_PROXY path, so the S3 endpoint host must be allowed or
+                     every pull 403s. Auto-add it from the configured endpoint
+                     unless the operator already listed it. */}}
+              {{- with .Values.config.storage.tarball.s3.endpoint }}
+                {{- $s3Host := (urlParse .).host }}
+                {{- if and $s3Host (not (has $s3Host $systemHosts)) }}
+                  {{- $systemHosts = append $systemHosts $s3Host }}
+                {{- end }}
               {{- end }}
             {{- end }}
             - --system-hosts={{ join "," $systemHosts }}

--- a/deploy/helm/vibed/templates/warmpools.yaml
+++ b/deploy/helm/vibed/templates/warmpools.yaml
@@ -54,20 +54,43 @@ spec:
         - name: runtime
           image: {{ $cfg.image | quote }}
           imagePullPolicy: IfNotPresent
-          {{- if $root.Values.egressControl.enabled }}
-          # Route outbound HTTP(S) through the egress proxy — the NetworkPolicy
-          # blocks every other egress path, so this is the only way out and the
-          # proxy authorizes it against the app's allow-list. lower+upper case
-          # since libraries differ on which they read.
-          {{- $proxy := printf "http://%s-egress-proxy.%s:3128" (include "vibed.fullname" $root) $root.Release.Namespace }}
           env:
+            {{- if $root.Values.egressControl.enabled }}
+            # Route outbound HTTP(S) through the egress proxy — the NetworkPolicy
+            # blocks every other egress path, so this is the only way out and the
+            # proxy authorizes it against the app's allow-list. lower+upper case
+            # since libraries differ on which they read.
+            {{- $proxy := printf "http://%s-egress-proxy.%s:3128" (include "vibed.fullname" $root) $root.Release.Namespace }}
             - { name: HTTP_PROXY,  value: {{ $proxy | quote }} }
             - { name: HTTPS_PROXY, value: {{ $proxy | quote }} }
             - { name: NO_PROXY,    value: "localhost,127.0.0.1" }
             - { name: http_proxy,  value: {{ $proxy | quote }} }
             - { name: https_proxy, value: {{ $proxy | quote }} }
             - { name: no_proxy,    value: "localhost,127.0.0.1" }
-          {{- end }}
+            {{- end }}
+            # Bearer token for the agent control API (:9000). This reads a Secret
+            # of the same name in THIS (apps) namespace; the controller reads a
+            # separate Secret object of the same name in the release namespace, so
+            # create both with the SAME token value or injects 401. optional:true
+            # keeps installs without the Secret working (unauthenticated — dev /
+            # single-node). Create it to authenticate the control API against the
+            # untrusted workload that shares this pod's network namespace:
+            #   kubectl create secret generic {{ include "vibed.fullname" $root }}-agent-token \
+            #     --from-literal=token=$(openssl rand -hex 32) -n {{ $root.Values.namespaces.apps }}
+            # (the controller reads the same Secret in its own namespace).
+            - name: VIBED_AGENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vibed.fullname" $root }}-agent-token
+                  key: token
+                  optional: true
+            {{- with $root.Values.agentAuth }}
+            {{- if .require }}
+            # Fail closed: the control API refuses inject/stop/status/logs when no
+            # token is configured (defense-in-depth against a missing Secret).
+            - { name: VIBED_AGENT_REQUIRE_AUTH, value: "true" }
+            {{- end }}
+            {{- end }}
           ports:
             - { name: control, containerPort: 9000 }
             - { name: http,    containerPort: 8080 }

--- a/deploy/helm/vibed/values-production.yaml
+++ b/deploy/helm/vibed/values-production.yaml
@@ -6,12 +6,28 @@
 #     -n vibed-system --create-namespace
 #
 # IMPORTANT: Review and customize these values before deploying.
-# At minimum, update: image.tag, config.registry.url, and
-# auth.existingSecret.
+#
+# This file ships a HARDENED, secure-by-default posture: the sandbox
+# NetworkPolicy, per-app egress allow-list, HTTP rate limiting, and agent
+# control-API authentication are all ON. Two of these have prerequisites you
+# MUST satisfy or deploys will fail:
+#   1. The NetworkPolicy blocks cluster-internal egress, so source tarballs must
+#      come from S3 — set config.storage.tarball.s3.* (endpoint/bucket/region)
+#      and provide credentials (IRSA or env).
+#   2. The agent control API is set to fail closed. Generate ONE token and apply
+#      the SAME value to BOTH the release namespace and namespaces.apps (the
+#      controller and the warm-pool pods read it from their own namespace, so
+#      the values must match or injects fail):
+#        TOKEN=$(openssl rand -hex 32)
+#        for ns in vibed-system vibed-apps; do
+#          kubectl create secret generic vibed-agent-token \
+#            --from-literal=token="$TOKEN" -n "$ns"
+#        done
+# At minimum also update: image.tag, config.registry.url, auth.existingSecret.
 
 image:
   # -- Pin to a specific release tag. Never use "latest" in production.
-  tag: "v0.1.0"
+  tag: "v0.4.2"
   pullPolicy: Always
 
 resources:
@@ -41,10 +57,38 @@ auth:
     #   kubectl create secret tls vibed-tls --cert=tls.crt --key=tls.key -n vibed-system
     existingSecret: ""
 
+# -- Sandbox isolation posture. Unmanaged hands networking to vibeD's own
+#    NetworkPolicy (below); required for the egress allow-list to apply.
+runtime:
+  sandboxNetworkPolicy: Unmanaged
+
+# -- Default-deny NetworkPolicy for sandbox pods. With egressControl on, the only
+#    egress is DNS and the egress proxy (no direct public path), so untrusted code
+#    can reach nothing else. The presigned S3 tarball pull goes through the proxy
+#    and is auto-allowed (the egress-authz sidecar adds the S3 endpoint host to
+#    its system-hosts from config.storage.tarball.s3.endpoint).
+networkPolicy:
+  enabled: true
+
+# -- Per-app outbound allow-list enforced by a forward proxy, so untrusted code
+#    can only reach the hosts an app declares.
+egressControl:
+  enabled: true
+
+# -- Fail closed on the in-sandbox agent control API. Requires the
+#    vibed-agent-token Secret (see header); without it, deploys fail.
+agentAuth:
+  require: true
+
 config:
   server:
     transport: "http"
     httpAddr: ":8080"
+    # -- Throttle per-client request rate (the deploy path is expensive).
+    rateLimit:
+      enabled: true
+      requestsPerSecond: 10
+      burst: 20
   deployment:
     preferredTarget: "auto"
     namespace: "default"
@@ -52,6 +96,15 @@ config:
     backend: "local"
     local:
       basePath: "/data/vibed/artifacts"
+    # -- Source tarballs MUST come from S3 in this posture: the NetworkPolicy
+    #    blocks the in-cluster "served" backend. Fill in your bucket + creds.
+    tarball:
+      backend: "s3"
+      s3:
+        endpoint: ""   # e.g. https://s3.us-east-1.amazonaws.com
+        bucket: ""     # e.g. vibed-sources
+        region: ""     # e.g. us-east-1
+        presignTTL: "15m"
   registry:
     enabled: true
     # -- Your production OCI registry (e.g., ghcr.io/myorg/vibed-artifacts)

--- a/deploy/helm/vibed/values.yaml
+++ b/deploy/helm/vibed/values.yaml
@@ -95,6 +95,23 @@ runtime:
   #               policy = fully open.)
   sandboxNetworkPolicy: Managed
 
+# -- Authentication for the in-sandbox agent control API (:9000), which the
+#    controller uses to inject source and manage the user process. The token is
+#    supplied via a Secret named "<release>-agent-token" (key "token") that both
+#    the controller and the warm-pool pods read. Generate ONE value and apply it
+#    to BOTH the release namespace and namespaces.apps (they must match):
+#      TOKEN=$(openssl rand -hex 32)
+#      for ns in <release-ns> <apps-ns>; do
+#        kubectl create secret generic <release>-agent-token \
+#          --from-literal=token="$TOKEN" -n "$ns"
+#      done
+agentAuth:
+  # -- Fail closed: the agent refuses the control API (inject/stop/status/logs)
+  #    when no token is configured, instead of serving it unauthenticated to the
+  #    untrusted workload sharing the pod. Only enable together with the Secret
+  #    above, or deploys will fail. Health/info probes stay unauthenticated.
+  require: false
+
 # -- Bring-your-own base-image validation. When enabled (default), the
 #    controller periodically boots-checks each warm-pool image (agent /info +
 #    language match + runtime probe) and hard-gates deploys whose image is

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -16,6 +16,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -235,8 +236,14 @@ func autoProvisionAPIKeyUser(ctx context.Context, userStore store.UserStore, key
 }
 
 // oauthPassthroughVerifier accepts a Bearer token that must match an API key
-// (acting as a proxy shared secret) and then trusts the X-Forwarded-User header.
-func oauthPassthroughVerifier(keys []config.APIKeyConf, logger *slog.Logger) mcpauth.TokenVerifier {
+// (acting as a proxy shared secret) and then trusts the X-Forwarded-User header
+// — but ONLY when the request originates from a trusted proxy (its source IP is
+// within one of trustedCIDRs). This binds the identity header to the proxy, so a
+// direct client that learns the shared secret cannot spoof an arbitrary user (or
+// an admin) by setting the header itself. When no trusted proxies are
+// configured, the header is never trusted and every request maps to the generic
+// "oauth-user" identity.
+func oauthPassthroughVerifier(keys []config.APIKeyConf, trustedCIDRs []*net.IPNet, logger *slog.Logger) mcpauth.TokenVerifier {
 	return func(ctx context.Context, token string, req *http.Request) (*mcpauth.TokenInfo, error) {
 		if token == "" {
 			return nil, mcpauth.ErrInvalidToken
@@ -256,10 +263,15 @@ func oauthPassthroughVerifier(keys []config.APIKeyConf, logger *slog.Logger) mcp
 			return nil, mcpauth.ErrInvalidToken
 		}
 
-		// Extract user ID from X-Forwarded-User header if set by the proxy
-		userID := req.Header.Get("X-Forwarded-User")
-		if userID == "" {
-			userID = "oauth-user"
+		// Trust the identity header only from a configured trusted proxy.
+		userID := "oauth-user"
+		if fwd := req.Header.Get("X-Forwarded-User"); fwd != "" {
+			if remoteIPTrusted(req.RemoteAddr, trustedCIDRs) {
+				userID = fwd
+			} else {
+				logger.Warn("OAuth passthrough: ignoring X-Forwarded-User from an untrusted source",
+					"remote", req.RemoteAddr, "path", req.URL.Path)
+			}
 		}
 
 		logger.Debug("OAuth passthrough authenticated",
@@ -272,6 +284,42 @@ func oauthPassthroughVerifier(keys []config.APIKeyConf, logger *slog.Logger) mcp
 			Expiration: time.Now().Add(1 * time.Hour),
 		}, nil
 	}
+}
+
+// parseTrustedProxies parses CIDR strings into networks, logging and skipping any
+// that are malformed.
+func parseTrustedProxies(cidrs []string, logger *slog.Logger) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(strings.TrimSpace(c))
+		if err != nil {
+			logger.Warn("ignoring malformed auth.trustedProxies CIDR", "value", c, "error", err)
+			continue
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+// remoteIPTrusted reports whether remoteAddr's IP is within any trusted CIDR.
+func remoteIPTrusted(remoteAddr string, trusted []*net.IPNet) bool {
+	if len(trusted) == 0 {
+		return false
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr // no port
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, n := range trusted {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // BuildRoleMap creates a mapping from user ID (APIKey Name) to role.

--- a/internal/auth/providers.go
+++ b/internal/auth/providers.go
@@ -23,7 +23,11 @@ func init() {
 		if len(cfg.APIKeys) == 0 {
 			return nil, fmt.Errorf("auth.mode is 'oauth' but no API keys (proxy secrets) are configured")
 		}
-		return &Provider{Verifier: oauthPassthroughVerifier(cfg.APIKeys, logger)}, nil
+		trusted := parseTrustedProxies(cfg.TrustedProxies, logger)
+		if len(trusted) == 0 {
+			logger.Warn("auth.mode 'oauth' has no auth.trustedProxies configured: X-Forwarded-User will be ignored and all requests map to a single 'oauth-user' identity. Set auth.trustedProxies to the proxy CIDR(s) to enable per-user identity.")
+		}
+		return &Provider{Verifier: oauthPassthroughVerifier(cfg.APIKeys, trusted, logger)}, nil
 	})
 
 	RegisterProvider("oidc", func(cfg config.AuthConfig, userStore store.UserStore, logger *slog.Logger) (*Provider, error) {

--- a/internal/auth/xff_test.go
+++ b/internal/auth/xff_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vibed-project/vibeD/internal/config"
+)
+
+// TestOAuthPassthroughTrustsForwardedUserOnlyFromTrustedProxy locks in the fix
+// for the X-Forwarded-User spoofing issue: the identity header is honored only
+// when the request originates from a configured trusted-proxy CIDR.
+func TestOAuthPassthroughTrustsForwardedUserOnlyFromTrustedProxy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const secret = "proxy-secret"
+	keys := []config.APIKeyConf{{Key: secret, Name: "proxy"}}
+	trusted := parseTrustedProxies([]string{"10.0.0.0/8"}, logger)
+	verifier := oauthPassthroughVerifier(keys, trusted, logger)
+
+	userIDFrom := func(remote, fwd string) string {
+		r := httptest.NewRequest("GET", "/mcp", nil)
+		r.RemoteAddr = remote
+		if fwd != "" {
+			r.Header.Set("X-Forwarded-User", fwd)
+		}
+		info, err := verifier(context.Background(), secret, r)
+		if err != nil {
+			t.Fatalf("verifier(%s,%s): unexpected error %v", remote, fwd, err)
+		}
+		return info.UserID
+	}
+
+	// From a trusted proxy → the forwarded identity is honored.
+	if got := userIDFrom("10.1.2.3:5555", "alice"); got != "alice" {
+		t.Errorf("trusted proxy: UserID = %q, want alice", got)
+	}
+	// From an untrusted source → the header is ignored (generic identity).
+	if got := userIDFrom("203.0.113.9:4444", "admin"); got != "oauth-user" {
+		t.Errorf("untrusted source: UserID = %q, want oauth-user (header must not be trusted)", got)
+	}
+	// No header → generic identity.
+	if got := userIDFrom("10.1.2.3:5555", ""); got != "oauth-user" {
+		t.Errorf("no header: UserID = %q, want oauth-user", got)
+	}
+
+	// With no trusted proxies configured, the header is never trusted.
+	verifierNoTrust := oauthPassthroughVerifier(keys, nil, logger)
+	r := httptest.NewRequest("GET", "/mcp", nil)
+	r.RemoteAddr = "10.1.2.3:5555"
+	r.Header.Set("X-Forwarded-User", "admin")
+	info, err := verifierNoTrust(context.Background(), secret, r)
+	if err != nil {
+		t.Fatalf("no-trust verifier: %v", err)
+	}
+	if info.UserID != "oauth-user" {
+		t.Errorf("no trusted proxies: UserID = %q, want oauth-user", info.UserID)
+	}
+
+	// A wrong proxy secret is still rejected.
+	r2 := httptest.NewRequest("GET", "/mcp", nil)
+	r2.RemoteAddr = "10.1.2.3:5555"
+	if _, err := verifier(context.Background(), "wrong", r2); err == nil {
+		t.Error("expected error for invalid proxy secret")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,13 @@ type AuthConfig struct {
 	APIKeys []APIKeyConf `yaml:"apiKeys"`
 	OIDC    OIDCConfig   `yaml:"oidc"`
 	TLS     TLSConf      `yaml:"tls"`
+	// TrustedProxies is a list of CIDRs (e.g. "10.0.0.0/8") for the "oauth"
+	// passthrough mode. The X-Forwarded-User identity header is trusted ONLY when
+	// the request's source IP falls within one of these CIDRs. If empty, the
+	// header is not trusted (every request maps to a generic identity), so a
+	// direct client cannot spoof a user by setting the header. Ignored by the
+	// apikey/oidc modes.
+	TrustedProxies []string `yaml:"trustedProxies,omitempty"`
 	// Options is a generic bag read by out-of-tree auth providers. Core providers
 	// (apikey/oauth/oidc) ignore it, so a new mode needs no field added to this
 	// struct.

--- a/internal/runneragent/agent.go
+++ b/internal/runneragent/agent.go
@@ -2,6 +2,7 @@ package runneragent
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +37,11 @@ type Config struct {
 	// Token, when non-empty, is required as a Bearer token on every control
 	// API request. vibeD passes the same value via the VIBED_AGENT_TOKEN env.
 	Token string
+	// RequireAuth makes the control API (inject/status/logs/stop) fail closed
+	// when no Token is configured, instead of serving those endpoints
+	// unauthenticated. Set via VIBED_AGENT_REQUIRE_AUTH=true. It does not affect
+	// the unauthenticated liveness (/healthz) and image-info (/info) probes.
+	RequireAuth bool
 	// AppPort is the default port the user process should listen on; exported
 	// to the process as PORT. An InjectRequest may override it per-deploy.
 	AppPort int
@@ -156,15 +162,27 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 }
 
-// auth wraps a handler with Bearer-token authentication when a token is set.
+// auth wraps a control-API handler with Bearer-token authentication.
+//
+// When a Token is configured it is required (constant-time compared). When no
+// Token is configured the behavior depends on RequireAuth: if set, the endpoint
+// fails closed (401) so a misconfiguration cannot silently expose the control
+// API to the untrusted workload sharing the pod; if unset, the endpoint is
+// served without auth (the historical single-node/dev default).
 func (a *Agent) auth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if a.cfg.Token != "" {
-			got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-			if got != a.cfg.Token {
-				writeError(w, http.StatusUnauthorized, "invalid or missing bearer token")
+		if a.cfg.Token == "" {
+			if a.cfg.RequireAuth {
+				writeError(w, http.StatusUnauthorized, "control API requires authentication but no token is configured")
 				return
 			}
+			next(w, r)
+			return
+		}
+		got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if subtle.ConstantTimeCompare([]byte(got), []byte(a.cfg.Token)) != 1 {
+			writeError(w, http.StatusUnauthorized, "invalid or missing bearer token")
+			return
 		}
 		next(w, r)
 	}

--- a/internal/runneragent/agent_test.go
+++ b/internal/runneragent/agent_test.go
@@ -218,6 +218,41 @@ func TestAuthRequired(t *testing.T) {
 	}
 }
 
+// TestRequireAuthFailsClosed verifies that with no token configured, the control
+// API is open by default (legacy single-node behavior) but fails closed when
+// RequireAuth is set — while the health probe stays open in both cases.
+func TestRequireAuthFailsClosed(t *testing.T) {
+	newSrv := func(cfg Config) *httptest.Server {
+		cfg.Workdir = t.TempDir()
+		cfg.AppPort = 8080
+		cfg.StopGrace = time.Second
+		a := New(cfg)
+		srv := httptest.NewServer(a.handler())
+		t.Cleanup(srv.Close)
+		t.Cleanup(func() { a.stopProcess() })
+		return srv
+	}
+
+	// No token, RequireAuth off → control API open (unchanged default).
+	open := newSrv(Config{})
+	if resp, _ := do(t, open, http.MethodGet, PathStatus, "", nil); resp.StatusCode != http.StatusOK {
+		t.Fatalf("no-token/require-off: expected 200 (open), got %d", resp.StatusCode)
+	}
+
+	// No token, RequireAuth on → control API fails closed.
+	closed := newSrv(Config{RequireAuth: true})
+	if resp, _ := do(t, closed, http.MethodGet, PathStatus, "", nil); resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("no-token/require-on: expected 401 (fail closed), got %d", resp.StatusCode)
+	}
+	if resp, _ := do(t, closed, http.MethodPost, PathInject, "", map[string]any{"command": []string{"x"}}); resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("no-token/require-on: inject expected 401, got %d", resp.StatusCode)
+	}
+	// Health probe stays open even when fail-closed.
+	if resp, _ := do(t, closed, http.MethodGet, PathHealthz, "", nil); resp.StatusCode != http.StatusOK {
+		t.Fatalf("no-token/require-on: healthz must stay open, got %d", resp.StatusCode)
+	}
+}
+
 func TestWriteFilesRejectsTraversal(t *testing.T) {
 	root := t.TempDir()
 	for _, bad := range []string{"../escape", "/etc/passwd", "a/../../escape"} {


### PR DESCRIPTION
## Summary

Hardens the public core against the highest-severity findings from the recent security review, and makes the production Helm posture secure by default. Every change is behavior-preserving for the default single-node config (no token / no trusted proxy configured); the hardening activates when an operator provides the corresponding secret/config.

## Changes

### 1. OAuth passthrough no longer trusts a spoofable identity header (#44)
`oauth` mode previously trusted `X-Forwarded-User` from any client that knew the shared proxy secret — allowing a direct caller to impersonate any user (including an admin, since the role is resolved from that ID). Now the header is honored **only** when the request's source IP is within a configured `auth.trustedProxies` CIDR; otherwise every request maps to a generic `oauth-user` identity. A startup warning fires when `oauth` mode has no trusted proxies set.

### 2. Activated the vibed-agent control-API token + fail-closed option (#45, #61)
The `:9000` agent control API (`/inject`, `/stop`, …) was effectively unauthenticated because the token path was inert end-to-end: the controller set `VIBED_AGENT_TOKEN` but its `-agent-token` flag never read it, and warm-pool pods carried no token. This:
- makes the controller default `-agent-token` to `$VIBED_AGENT_TOKEN`,
- wires the same optional `…-agent-token` Secret into the warm-pool pods,
- adds an opt-in fail-closed mode (`VIBED_AGENT_REQUIRE_AUTH`) so a missing token refuses the control API instead of serving it to the untrusted workload sharing the pod (health/info probes stay open),
- switches the token compare to `crypto/subtle.ConstantTimeCompare`.

### 3. Secure-by-default `values-production.yaml` (#47, #50)
Turns on the sandbox NetworkPolicy, per-app egress allow-list, HTTP rate limiting, and agent-API auth, and switches the tarball backend to S3 (the NetworkPolicy blocks the in-cluster "served" pull). The egress-authz sidecar now **auto-allows the S3 endpoint host** (mirroring the served-store branch), so the source pull works under the locked-down policy. The header documents the two prerequisites (S3 config + the agent-token Secret in both namespaces).

## Tests / verification
- New unit tests: `X-Forwarded-User` trust boundary (`internal/auth/xff_test.go`) and agent fail-closed behavior (`TestRequireAuthFailsClosed`).
- `go build ./...`, `go vet ./...`, full `go test ./...` green.
- `helm template` verified for the default posture (token env from optional Secret, no fail-closed) and the production posture (Unmanaged, NetworkPolicy on, `VIBED_AGENT_REQUIRE_AUTH=true`, S3 host in `--system-hosts`); `agentAuth: null` no longer panics.
- The diff was run through an adversarial review; the one deploy-breaking issue it found (S3 host missing from the egress allow-list) is fixed here.

## Residual / follow-ups (not in this PR)
- The `X-Forwarded-User` check trusts the **direct TCP peer**; it is only sound if the OAuth proxy is the immediate peer of the vibeD Service (an L7 ingress hop between them would need separate handling). `auth.trustedProxies` currently has no Helm value surface — set it via raw config.
- #50: rate limiting is enabled in production but still doesn't cover `/v1/*`; broader coverage + a per-user write-verb limiter class remains open.
- #45: enforcement is opt-in via the agent-token Secret; the OSS default (`values.yaml`) stays open for single-node/dev. Cross-namespace Secret sync and the S3-under-egress path still warrant a cluster e2e.
