### PR TITLE
docs(blog): v0.4.x recap + citizen-developer governance posts

### DIFF
--- a/docs/blog/2026-07-05-citizen-developers.md
+++ b/docs/blog/2026-07-05-citizen-developers.md
@@ -5,9 +5,9 @@ authors: [max]
 tags: [governance, use-case]
 ---
 
-Something is happening in every company right now: people who aren't professional developers are using AI to **vibe-code small tools**. A dashboard for their team. A form that writes to a spreadsheet. A scraper that watches a supplier's price page. The tool works — and then it lives on a laptop, or gets pasted into some third-party host with a company API key baked into it.
+Something is happening in every company right now: people who aren't professional developers are using AI to **vibe-code small tools**. A dashboard for their team. A form that writes to a spreadsheet. A scraper that watches a supplier's price page. The tool works and then it lives on a laptop, or gets pasted into some third-party host with a company API key baked into it.
 
-That's the classic **shadow-IT** problem, except now it happens at AI speed and in far greater volume. The instinct is to lock it down. But telling a motivated employee "no" just pushes the tool somewhere you can't see. The better answer is to give that app **a place to land** — self-hosted, isolated, governed — that's so fast and easy it beats the laptop.
+That's the classic **shadow-IT** problem, except now it happens at AI speed and in far greater volume. The instinct is to lock it down. But telling a motivated employee "no" just pushes the tool somewhere you can't see. The better answer is to give that app **a place to land**, self-hosted, isolated, governed spot that's so fast and easy it beats the laptop.
 
 That's the problem vibeD exists to solve.
 
@@ -15,31 +15,31 @@ That's the problem vibeD exists to solve.
 
 ## The citizen developer
 
-vibeD's target user has always been the **employee who vibe-coded a small tool with GenAI and wants it captured into a governed sandbox instead of living on their laptop**. They're not going to file a ticket, wait for a platform team, or learn Kubernetes. They point their AI agent at vibeD (over MCP or the HTTP API), and seconds later their app is at a real URL.
+vibeD's target user is the **employee who vibe-coded a small tool with GenAI and wants it captured into a governed sandbox instead of living on their laptop**. They're not going to file a ticket, wait for a platform team, or learn Kubernetes. They point their AI agent at vibeD (over MCP or the HTTP API), and seconds later their app is at a real URL.
 
-The company's job is different: make sure that when a hundred of those apps show up, each one is **isolated, scoped, owned, and auditable** — without adding the friction that sends people back to the laptop. Everything below ships in the open-source core.
+The company's job is different: make sure that when a hundred of those apps show up, each one is **isolated, scoped, owned and auditable**, without adding the friction that sends people back to the laptop.
 
 ## 1. Untrusted code, contained
 
-Citizen-developer apps are, by definition, code nobody reviewed. So vibeD runs each one in a **Kata + Firecracker microVM** — hardware-grade isolation, not a shared container on a shared host. A tool that misbehaves (or that the model got subtly wrong) is boxed into its own microVM with its own kernel. The blast radius is one app, not your cluster or someone's workstation.
+Citizen-developer apps are, by definition, code nobody reviewed. The ones that run arbitrary code (Node, Python, Go, or a custom image) land in vibeD's **general lane**, where each app runs in its own **Kata Containers microVM**: a real guest kernel and hardware-grade isolation, not a shared container on a shared host. You choose the hypervisor through the Kata RuntimeClass, either QEMU (`kata-qemu`, the default, which runs even without nested virt) or **Firecracker** (`kata-fc`) on KVM and bare-metal nodes. A tool that misbehaves, or that the model got subtly wrong, is boxed into its own microVM; the blast radius is one app, not your cluster or someone's workstation. (Lightweight static sites and V8-isolate workers take a faster lane that trades the microVM for a lighter sandbox.)
 
 See [lanes and templates](/docs/concepts/lanes-and-templates).
 
 ## 2. The app can only reach what it declares
 
-The scariest thing about an AI-written tool isn't that it crashes — it's what it can *reach*. vibeD makes every app declare its **outbound allow-list** at deploy time, and enforces it at the network with a default-deny egress proxy:
+The scariest thing about an AI-written tool isn't that it crashes, it's what it can *reach*. vibeD makes every app declare its **outbound allow-list** at deploy time and enforces it at the network with a default-deny egress proxy:
 
 ```json
 {"name": "supplier-watcher", "allowed_hosts": ["api.supplier.com"]}
 ```
 
-That app can talk to `api.supplier.com` and nothing else — not your internal network, not the instance metadata endpoint, not an exfiltration server. Wildcards are anchored to real subdomains, and the only route out of a sandbox is through the authorizing proxy.
+That app can talk to `api.supplier.com` and nothing else, not your internal network, not the instance metadata endpoint, not an exfiltration server. Wildcards are anchored to real subdomains and the only route out of a sandbox is through the authorizing proxy.
 
 See [egress control](/docs/configuration/egress-control).
 
 ## 3. Only your people, with a real identity
 
-vibeD plugs into your existing identity provider over **OIDC** (Keycloak, Okta, Entra, Google, …), or uses API keys for programmatic access. Authentication is on before vibeD is ever exposed, so only your employees can deploy or reach apps — and every deploy carries an **owner**. Deactivate someone in your IdP and their access goes with them.
+vibeD plugs into your existing identity provider over **OIDC** (Keycloak, Okta, Entra, Google, …), or uses API keys for programmatic access. Authentication is on before vibeD is ever exposed, so only your employees can deploy or reach apps and every deploy carries an **owner**. Deactivate someone in your IdP and their access goes with them.
 
 See [authentication](/docs/configuration/authentication).
 

--- a/docs/blog/2026-07-05-citizen-developers.md
+++ b/docs/blog/2026-07-05-citizen-developers.md
@@ -1,0 +1,70 @@
+---
+slug: citizen-developers
+title: "A governed home for your citizen developers' AI apps"
+authors: [max]
+tags: [governance, use-case]
+---
+
+Something is happening in every company right now: people who aren't professional developers are using AI to **vibe-code small tools**. A dashboard for their team. A form that writes to a spreadsheet. A scraper that watches a supplier's price page. The tool works — and then it lives on a laptop, or gets pasted into some third-party host with a company API key baked into it.
+
+That's the classic **shadow-IT** problem, except now it happens at AI speed and in far greater volume. The instinct is to lock it down. But telling a motivated employee "no" just pushes the tool somewhere you can't see. The better answer is to give that app **a place to land** — self-hosted, isolated, governed — that's so fast and easy it beats the laptop.
+
+That's the problem vibeD exists to solve.
+
+<!-- truncate -->
+
+## The citizen developer
+
+vibeD's target user has always been the **employee who vibe-coded a small tool with GenAI and wants it captured into a governed sandbox instead of living on their laptop**. They're not going to file a ticket, wait for a platform team, or learn Kubernetes. They point their AI agent at vibeD (over MCP or the HTTP API), and seconds later their app is at a real URL.
+
+The company's job is different: make sure that when a hundred of those apps show up, each one is **isolated, scoped, owned, and auditable** — without adding the friction that sends people back to the laptop. Everything below ships in the open-source core.
+
+## 1. Untrusted code, contained
+
+Citizen-developer apps are, by definition, code nobody reviewed. So vibeD runs each one in a **Kata + Firecracker microVM** — hardware-grade isolation, not a shared container on a shared host. A tool that misbehaves (or that the model got subtly wrong) is boxed into its own microVM with its own kernel. The blast radius is one app, not your cluster or someone's workstation.
+
+See [lanes and templates](/docs/concepts/lanes-and-templates).
+
+## 2. The app can only reach what it declares
+
+The scariest thing about an AI-written tool isn't that it crashes — it's what it can *reach*. vibeD makes every app declare its **outbound allow-list** at deploy time, and enforces it at the network with a default-deny egress proxy:
+
+```json
+{"name": "supplier-watcher", "allowed_hosts": ["api.supplier.com"]}
+```
+
+That app can talk to `api.supplier.com` and nothing else — not your internal network, not the instance metadata endpoint, not an exfiltration server. Wildcards are anchored to real subdomains, and the only route out of a sandbox is through the authorizing proxy.
+
+See [egress control](/docs/configuration/egress-control).
+
+## 3. Only your people, with a real identity
+
+vibeD plugs into your existing identity provider over **OIDC** (Keycloak, Okta, Entra, Google, …), or uses API keys for programmatic access. Authentication is on before vibeD is ever exposed, so only your employees can deploy or reach apps — and every deploy carries an **owner**. Deactivate someone in your IdP and their access goes with them.
+
+See [authentication](/docs/configuration/authentication).
+
+## 4. Ownership, teams, and quotas
+
+Every app has an owner, and owners roll up into **departments**, each with its own namespace. Users see and manage their own apps; admins get the fleet view. **Per-owner and per-department quotas** cap how many concurrent apps a person or a team can run, hard-gated at the deploy path — so one enthusiastic team can't quietly consume the whole cluster.
+
+See [quotas](/docs/configuration/quotas).
+
+## 5. A record of what happened
+
+Governance means being able to answer "who deployed that, and when?" vibeD keeps an **append-only audit trail** of the mutating actions — deploy, update, rollback, delete — with the actor, the target, and the outcome. It's the baseline you need when a security or compliance team asks how an app got there.
+
+See [the audit log](/docs/configuration/audit-log).
+
+## 6. Your images, your cluster, your supply chain
+
+The built-in runtimes are a starting point, not a mandate. A platform or security team can **bring their own hardened base images** for any runtime slot, and vibeD's validator rejects images that don't match — including a strict mode that catches a mutable tag being re-pushed underneath you. Everything runs **on your own Kubernetes**, in your environment, so the data never leaves. Every vibeD image ships with an **SBOM and an in-registry attestation**.
+
+See [custom base images](/docs/configuration/custom-base-images).
+
+## Governance without the friction
+
+The point of all of this is that it's **not a tradeoff**. A citizen developer still gets their app to a live URL in seconds — the isolation, the egress allow-list, the ownership, the audit entry all happen automatically, around the fast path, not in front of it. That's the only kind of governance that actually sticks: the kind people don't route around, because the governed path is also the *easy* path.
+
+If your company is already seeing AI-built tools show up in places you can't see, that's the signal. Give them somewhere better to land.
+
+Start with the [installation guide](/docs/getting-started/installation) and the [architecture overview](/docs/concepts/architecture). The code is on [GitHub](https://github.com/vibed-project/vibeD).

--- a/docs/blog/2026-07-05-vibed-v0.4-so-far.md
+++ b/docs/blog/2026-07-05-vibed-v0.4-so-far.md
@@ -1,0 +1,62 @@
+---
+slug: vibed-v0.4-so-far
+title: "vibeD v0.4.x — Governance, a Build-Free Core, and Extension Points"
+authors: [max]
+tags: [release]
+---
+
+v0.3.1 was about **speed** — an AI-generated app to a live URL in seconds, never building a container on the deploy path. The whole v0.4 line has been about everything *around* that hot path: making vibeD **defensible**, **lean**, and **extensible**, without ever slowing the "the model wrote it, it's live" loop.
+
+Here's what actually landed across **v0.4.0 → v0.4.3**.
+
+<!-- truncate -->
+
+## v0.4.0 — the governance release
+
+v0.3.1 made deploys fast; v0.4.0 made them *defensible*. This is the release where vibeD stopped being "a fast way to run AI code" and started being "a fast way to run AI code you can hand to a security team."
+
+- **Per-app egress control.** Every app declares its outbound allow-list at deploy time (`allowed_hosts: ["api.openweathermap.org", "*.example.com"]`) and vibeD enforces it *at the network*: a Squid forward proxy on the egress path, a `vibed-egress-authz` sidecar authorizing each connection by source-pod IP, and a NetworkPolicy that makes the proxy the only way out. **Default-deny**, wildcards anchored to real subdomains (`evil-example.com` doesn't match `*.example.com`).
+- **Deploy quotas.** Per-owner and per-department concurrent-app ceilings, hard-gated at the deploy path (`429` when you hit the limit). Redeploys of an existing app are never blocked.
+- **An append-only audit trail** of who deployed, changed, rolled back, or deleted what.
+- **Bring-your-own base images.** The five built-in templates became a *default*, not a requirement. Register your own hardened image for any slot as long as it meets the BYO contract; a controller-side **validator** boots-checks every warm-pool image and *fails deploys fast* with a clear reason instead of breaking apps silently. `templateValidation.strict` also rejects deploys when a warm pod's image digest drifts from the validated one.
+- A real **suspend / resume** lifecycle, the last `501` API gaps closed (log streaming, redeploy), and **SBOMs** for every image.
+
+## v0.4.1 — a build-free core
+
+v0.3.1 *added* the warm-sandbox path; v0.4.1 *deleted the old one*. The Buildah / buildpacks image-builder is gone — `internal/builder/` and all its scaffolding removed. **Tarball + warm-sandbox injection is now the only deploy path.** The orchestrator was gutted to a thin static-only fallback, Knative was dropped as a target, and builder-related config was stripped out.
+
+The result is a much smaller, simpler control plane with one deploy story — and every image ships an SPDX **SBOM plus an in-registry attestation** you can inspect with `docker buildx imagetools inspect`.
+
+## v0.4.2 — extension points
+
+Under the hood, the control plane became a set of **registries**. Storage, authentication, tenancy, deploy-time policy, usage metering, and secret schemes are all looked up by name, so you can supply your own implementation of any of them from a **separate Go module** — no fork, no patch:
+
+- pluggable **store backends** (`store.backend`) and **auth providers** (`auth.mode`),
+- a **`Tenant` / `TenantResolver`** seam (ships a single implicit tenant, so single-tenant behavior is unchanged),
+- a deploy-time **`PolicyGate`** and a usage **`MeterSink`**,
+- a pluggable **secret-scheme resolver** (`env:` / `file:` built in; add your own),
+- the public **`pkg/plugin`** façade + reusable **`pkg/server`** builder, so a custom binary is just *blank-import your provider, call `server.Main()`*,
+- enriched **audit events** (tenant, source hash, policy decision) and a CI **import-boundary** check.
+
+This is all documented in the new **[Extending vibeD](/docs/extending/overview)** section. Every seam ships a no-op default, so a stock install behaves exactly as before.
+
+## v0.4.3 — secure by default
+
+The extension points made it easy to tighten the defaults. v0.4.3 closes the highest-severity findings from a security review of the core:
+
+- **No identity spoofing in proxy mode.** The `oauth` passthrough now trusts the `X-Forwarded-User` header only when the request comes from a configured trusted-proxy CIDR (`auth.trustedProxies`); otherwise it maps to a generic identity. A direct caller that learns the shared secret can no longer impersonate a user.
+- **The in-sandbox agent control API is authenticated.** The agent token is now wired end-to-end (controller → warm-pool pods via a shared Secret), with an opt-in fail-closed mode and a constant-time token compare — so the untrusted workload sharing a pod can't drive the agent.
+- **`values-production.yaml` ships hardened.** Sandbox NetworkPolicy, per-app egress allow-list, HTTP rate limiting, and agent-API auth are all **on**, with the S3 source backend and its endpoint auto-added to the egress allow-list so the locked-down policy still lets deploys through.
+
+## Try it
+
+```bash
+helm install vibed oci://ghcr.io/vibed-project/charts/vibed \
+  --version 0.4.2 -n vibed-system --create-namespace
+```
+
+Full prerequisites (agent-sandbox, a Kata RuntimeClass, a sandbox node pool) are in the [installation guide](/docs/getting-started/installation). One upgrade caveat carries over from the v0.4 line: **Helm doesn't upgrade CRDs**, so after bumping you must `kubectl apply` the current `VibedApp` CRD.
+
+## What's next
+
+More extension points, continued security hardening down the finding list, and per-tenant isolation options — all without touching the thing that makes vibeD vibeD: the model writes it, and it's live, governed, in seconds. The code is on [GitHub](https://github.com/vibed-project/vibeD) — tell us what breaks.

--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -20,7 +20,7 @@ The control plane is stateless. Durable state lives in the Kubernetes API (the `
 ## Data plane
 
 - **Warm pools** — one `SandboxWarmPool` + `SandboxTemplate` per runtime template, pre-booting idle sandboxes so a deploy never waits on a cold boot or an image build.
-- **Sandboxes** — a claimed warm sandbox runs the user's app. General-lane sandboxes are Kata + Firecracker microVMs; the fast lane uses workerd isolates / static nginx.
+- **Sandboxes** — a claimed warm sandbox runs the user's app. General-lane sandboxes are Kata microVMs (QEMU by default, or Firecracker on KVM/bare-metal); the fast lane uses workerd isolates / static nginx.
 - **vibed-agent** — a small Go binary baked into every template image, running as PID 1 inside the sandbox. The controller POSTs it the source URL; it pulls, extracts into `/workspace`, autodetects the entrypoint, and starts the user process. It exposes a control API on `:9000` and the app listens on `:8080`.
 
 ## The deploy flow

--- a/docs/docs/concepts/lanes-and-templates.md
+++ b/docs/docs/concepts/lanes-and-templates.md
@@ -11,7 +11,7 @@ vibeD exposes a uniform API. You don't pick a runtime — a deterministic **clas
 | Lane | Isolation | Used for |
 |---|---|---|
 | **fast** | V8 isolates (workerd) or static nginx | Static sites and small trusted-language workers. Sub-second cold start. |
-| **general** | Kata + Firecracker **microVM** | Arbitrary code — Node, Python, Go, or any image. Hardware-grade isolation. |
+| **general** | Kata **microVM** (QEMU or Firecracker) | Arbitrary code — Node, Python, Go, or any image. Hardware-grade isolation. |
 
 The fast lane has two flavors: `static-nginx` (a sandbox pod serving `/workspace`) and `workerd` (V8 isolates managed by a loader). The general lane always runs on a Kata microVM sandbox.
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ vibeD ships as a Helm chart and runs on any Kubernetes 1.29+ cluster with a comp
 1. **A Kubernetes cluster** (EKS/GKE/AKS or on-prem), 1.29+.
 2. **[agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) installed** (v0.4.5+). vibeD builds on its `Sandbox`, `SandboxTemplate`, `SandboxClaim`, and `SandboxWarmPool` CRDs and its controller. Install it before vibeD.
 3. **A Kata RuntimeClass** for the general lane — `kata-qemu` (works without nested virt) or `kata-fc` (Firecracker, needs KVM). The general lane runs user code in Kata microVMs.
-4. **A sandbox node pool** labeled `vibed.dev/sandbox-node: "true"` running `containerd` + `containerd-shim-kata-v2`. Kata + Firecracker needs KVM (bare metal, `*.metal` on AWS, or nested-virt images on GCP).
+4. **A sandbox node pool** labeled `vibed.dev/sandbox-node: "true"` running `containerd` + `containerd-shim-kata-v2`. Firecracker (`kata-fc`) needs KVM (bare metal, `*.metal` on AWS, or nested-virt images on GCP); `kata-qemu` runs without it.
 5. **Object storage** (S3 or MinIO) for source tarballs in production — see [storage](../configuration/storage.md).
 6. **A DNS-01 capable DNS provider** (Cloudflare, Route53, …) for Caddy's wildcard TLS cert on `*.<your-domain>`.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -32,7 +32,7 @@ vibeD never builds a container image on the deploy path. Instead it keeps **warm
 The HTTP API is uniform. A deterministic **classifier** inspects the source and picks a lane — you never choose a runtime by hand (though you can override):
 
 - **fast lane** — V8 isolates (workerd) and static sites. Sub-second, for trusted-language workloads.
-- **general lane** — Kata + Firecracker **microVMs** for hardware-grade isolation of arbitrary code (Node, Python, Go, or any image).
+- **general lane** — Kata **microVMs** (QEMU by default, Firecracker on KVM) for hardware-grade isolation of arbitrary code (Node, Python, Go, or any image).
 
 ## Key components
 


### PR DESCRIPTION
Two new blog posts for the docs site.

## 1. `vibed-v0.4-so-far` — *vibeD v0.4.x — Governance, a Build-Free Core, and Extension Points*
A recap of what landed across **v0.4.0 → v0.4.3**: the governance release (egress control, quotas, audit trail, BYO base images, lifecycle), the build-free core (Buildah removed, tarball + warm-sandbox as the only path, SBOMs), the extension registries + `pkg/plugin`/`pkg/server`, and the secure-by-default v0.4.3 hardening.

## 2. `citizen-developers` — *A governed home for your citizen developers' AI apps*
A positioning post on the shadow-IT-at-AI-speed problem and how the **open-source core** lets companies give citizen developers a fast-but-governed place to ship: microVM isolation, per-app egress allow-lists, OIDC identity + ownership, departments + quotas, an audit trail, and BYO images — all self-hosted, all around the fast path.

## Notes
- Both posts describe **only the open-source core**; scrubbed for any product-tier wording (no paid/edition/SAML/SCIM/etc.).
- `npx docusaurus build` is green (all links resolve).