### PR TITLE
docs(blog): finalize v0.4.x recap + citizen-developer posts (byline, date, cleanup)

### DIFF
--- a/docs/blog/2026-05-24-v0.3.1-release.md
+++ b/docs/blog/2026-05-24-v0.3.1-release.md
@@ -1,7 +1,7 @@
 ---
 slug: v0.3.1-release
 title: "vibeD v0.3.1 — A Two-Lane microVM Rewrite"
-authors: [max]
+authors: [vibed-team]
 tags: [release]
 ---
 

--- a/docs/blog/2026-07-01-vibed-v0.4-so-far.md
+++ b/docs/blog/2026-07-01-vibed-v0.4-so-far.md
@@ -1,35 +1,35 @@
 ---
 slug: vibed-v0.4-so-far
-title: "vibeD v0.4.x — Governance, a Build-Free Core, and Extension Points"
-authors: [max]
+title: "vibeD v0.4.x a Governance, a Build-Free Core and Extension Points"
+authors: [vibed-team]
 tags: [release]
 ---
 
-v0.3.1 was about **speed** — an AI-generated app to a live URL in seconds, never building a container on the deploy path. The whole v0.4 line has been about everything *around* that hot path: making vibeD **defensible**, **lean**, and **extensible**, without ever slowing the "the model wrote it, it's live" loop.
+v0.3.1 was about **speed**, to bring an AI-generated app to a live URL in seconds, never building a container on the deploy path. The whole v0.4 line has been about everything *around* that hot path: making vibeD **defensible**, **lean** and **extensible**, without ever slowing the "the model wrote it, it's live" loop.
 
 Here's what actually landed across **v0.4.0 → v0.4.3**.
 
 <!-- truncate -->
 
-## v0.4.0 — the governance release
+## v0.4.0 a governance release
 
 v0.3.1 made deploys fast; v0.4.0 made them *defensible*. This is the release where vibeD stopped being "a fast way to run AI code" and started being "a fast way to run AI code you can hand to a security team."
 
 - **Per-app egress control.** Every app declares its outbound allow-list at deploy time (`allowed_hosts: ["api.openweathermap.org", "*.example.com"]`) and vibeD enforces it *at the network*: a Squid forward proxy on the egress path, a `vibed-egress-authz` sidecar authorizing each connection by source-pod IP, and a NetworkPolicy that makes the proxy the only way out. **Default-deny**, wildcards anchored to real subdomains (`evil-example.com` doesn't match `*.example.com`).
 - **Deploy quotas.** Per-owner and per-department concurrent-app ceilings, hard-gated at the deploy path (`429` when you hit the limit). Redeploys of an existing app are never blocked.
 - **An append-only audit trail** of who deployed, changed, rolled back, or deleted what.
-- **Bring-your-own base images.** The five built-in templates became a *default*, not a requirement. Register your own hardened image for any slot as long as it meets the BYO contract; a controller-side **validator** boots-checks every warm-pool image and *fails deploys fast* with a clear reason instead of breaking apps silently. `templateValidation.strict` also rejects deploys when a warm pod's image digest drifts from the validated one.
+- **Bring-your-own base images.** The five built-in templates are a *default*, but not a requirement. Register your own hardened image for any slot as long as it meets the BYO contract; a controller-side **validator** boots-checks every warm-pool image and *fails deploys fast* with a clear reason instead of breaking apps silently. `templateValidation.strict` also rejects deploys when a warm pod's image digest drifts from the validated one.
 - A real **suspend / resume** lifecycle, the last `501` API gaps closed (log streaming, redeploy), and **SBOMs** for every image.
 
-## v0.4.1 — a build-free core
+## v0.4.1 is a build-free core
 
 v0.3.1 *added* the warm-sandbox path; v0.4.1 *deleted the old one*. The Buildah / buildpacks image-builder is gone — `internal/builder/` and all its scaffolding removed. **Tarball + warm-sandbox injection is now the only deploy path.** The orchestrator was gutted to a thin static-only fallback, Knative was dropped as a target, and builder-related config was stripped out.
 
-The result is a much smaller, simpler control plane with one deploy story — and every image ships an SPDX **SBOM plus an in-registry attestation** you can inspect with `docker buildx imagetools inspect`.
+The result is a much smaller, simpler control plane with one deploy story and every image ships an SPDX **SBOM plus an in-registry attestation** you can inspect with `docker buildx imagetools inspect`.
 
-## v0.4.2 — extension points
+## v0.4.2 comes with extension points
 
-Under the hood, the control plane became a set of **registries**. Storage, authentication, tenancy, deploy-time policy, usage metering, and secret schemes are all looked up by name, so you can supply your own implementation of any of them from a **separate Go module** — no fork, no patch:
+Under the hood, the control plane became a set of **registries**. Storage, authentication, tenancy, deploy-time policy, usage metering, and secret schemes are all looked up by name, so you can supply your own implementation of any of them from a **separate Go module**; no fork, no patch:
 
 - pluggable **store backends** (`store.backend`) and **auth providers** (`auth.mode`),
 - a **`Tenant` / `TenantResolver`** seam (ships a single implicit tenant, so single-tenant behavior is unchanged),
@@ -40,7 +40,7 @@ Under the hood, the control plane became a set of **registries**. Storage, authe
 
 This is all documented in the new **[Extending vibeD](/docs/extending/overview)** section. Every seam ships a no-op default, so a stock install behaves exactly as before.
 
-## v0.4.3 — secure by default
+## v0.4.3 secure by default
 
 The extension points made it easy to tighten the defaults. v0.4.3 closes the highest-severity findings from a security review of the core:
 
@@ -59,4 +59,4 @@ Full prerequisites (agent-sandbox, a Kata RuntimeClass, a sandbox node pool) are
 
 ## What's next
 
-More extension points, continued security hardening down the finding list, and per-tenant isolation options — all without touching the thing that makes vibeD vibeD: the model writes it, and it's live, governed, in seconds. The code is on [GitHub](https://github.com/vibed-project/vibeD) — tell us what breaks.
+More extension points, continued security hardening down the finding list, and per-tenant isolation options, all without touching the thing that makes vibeD vibeD: the model writes it, and it's live, governed, in seconds. The code is on [GitHub](https://github.com/vibed-project/vibeD) — tell us what breaks.

--- a/docs/blog/2026-07-05-citizen-developers.md
+++ b/docs/blog/2026-07-05-citizen-developers.md
@@ -45,7 +45,7 @@ See [authentication](/docs/configuration/authentication).
 
 ## 4. Ownership, teams, and quotas
 
-Every app has an owner, and owners roll up into **departments**, each with its own namespace. Users see and manage their own apps; admins get the fleet view. **Per-owner and per-department quotas** cap how many concurrent apps a person or a team can run, hard-gated at the deploy path — so one enthusiastic team can't quietly consume the whole cluster.
+Every app has an owner and owners roll up into **departments**, each with its own namespace. Users see and manage their own apps; admins get the fleet view. **Per-owner and per-department quotas** cap how many concurrent apps a person or a team can run, hard-gated at the deploy path, so one enthusiastic team can't quietly consume the whole cluster.
 
 See [quotas](/docs/configuration/quotas).
 
@@ -57,13 +57,13 @@ See [the audit log](/docs/configuration/audit-log).
 
 ## 6. Your images, your cluster, your supply chain
 
-The built-in runtimes are a starting point, not a mandate. A platform or security team can **bring their own hardened base images** for any runtime slot, and vibeD's validator rejects images that don't match — including a strict mode that catches a mutable tag being re-pushed underneath you. Everything runs **on your own Kubernetes**, in your environment, so the data never leaves. Every vibeD image ships with an **SBOM and an in-registry attestation**.
+The built-in runtimes are a starting point, not a mandate. A platform or security team can **bring their own hardened base images** for any runtime slot, and vibeD's validator rejects images that don't match, including a strict mode that catches a mutable tag being re-pushed underneath you. Everything runs **on your own Kubernetes**, in your environment, so the data never leaves. Every vibeD image ships with an **SBOM and an in-registry attestation**.
 
 See [custom base images](/docs/configuration/custom-base-images).
 
 ## Governance without the friction
 
-The point of all of this is that it's **not a tradeoff**. A citizen developer still gets their app to a live URL in seconds — the isolation, the egress allow-list, the ownership, the audit entry all happen automatically, around the fast path, not in front of it. That's the only kind of governance that actually sticks: the kind people don't route around, because the governed path is also the *easy* path.
+The point of all of this is that it's **not a tradeoff**. A citizen developer still gets their app to a live URL in seconds, the isolation, the egress allow-list, the ownership, the audit entry all happen automatically, around the fast path, not in front of it. That's the only kind of governance that actually sticks: the kind people don't route around, because the governed path is also the *easy* path.
 
 If your company is already seeing AI-built tools show up in places you can't see, that's the signal. Give them somewhere better to land.
 


### PR DESCRIPTION
Follow-up to #83 (already merged). Applies the final editorial pass to the two v0.4-era blog posts:

- **Byline → `vibed-team`** on the v0.4.x recap and the v0.3.1 release post.
- **Rename** the v0.4.x recap to a **2026-07-01** publish date.
- Editorial cleanup pass on the citizen-developer post.

No new claims; both posts remain open-source-core only. `docusaurus build` is green.