### PR TITLE
security: authenticate the agent control API by default (finish #45)

### DIFF
--- a/deploy/helm/vibed/templates/agent-token-secret.yaml
+++ b/deploy/helm/vibed/templates/agent-token-secret.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.agentAuth.autoGenerate }}
+{{- /*
+Shared bearer token for the in-sandbox agent control API (:9000). Created in
+BOTH the release namespace (read by the controller) and namespaces.apps (read by
+the warm-pool pods) with the SAME value, so the token always matches and the
+control API is authenticated by default instead of open to the untrusted
+workload sharing the pod.
+
+The value is stable across upgrades: we look up an existing Secret and reuse its
+token, generating a fresh one only on first install. Set agentAuth.autoGenerate
+to false to manage the Secret yourself.
+*/ -}}
+{{- $name := printf "%s-agent-token" (include "vibed.fullname" .) }}
+{{- $ns := .Release.Namespace }}
+{{- $appsNs := .Values.namespaces.apps }}
+{{- $token := "" }}
+{{- $existing := lookup "v1" "Secret" $ns $name }}
+{{- if and $existing $existing.data (index $existing.data "token") }}
+{{-   $token = index $existing.data "token" | b64dec }}
+{{- else }}
+{{-   $existingApps := lookup "v1" "Secret" $appsNs $name }}
+{{-   if and $existingApps $existingApps.data (index $existingApps.data "token") }}
+{{-     $token = index $existingApps.data "token" | b64dec }}
+{{-   else }}
+{{-     $token = randAlphaNum 48 }}
+{{-   end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "vibed.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ $token | quote }}
+{{- if ne $appsNs $ns }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ $appsNs }}
+  labels:
+    {{- include "vibed.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ $token | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/vibed/values.yaml
+++ b/deploy/helm/vibed/values.yaml
@@ -96,20 +96,21 @@ runtime:
   sandboxNetworkPolicy: Managed
 
 # -- Authentication for the in-sandbox agent control API (:9000), which the
-#    controller uses to inject source and manage the user process. The token is
-#    supplied via a Secret named "<release>-agent-token" (key "token") that both
-#    the controller and the warm-pool pods read. Generate ONE value and apply it
-#    to BOTH the release namespace and namespaces.apps (they must match):
-#      TOKEN=$(openssl rand -hex 32)
-#      for ns in <release-ns> <apps-ns>; do
-#        kubectl create secret generic <release>-agent-token \
-#          --from-literal=token="$TOKEN" -n "$ns"
-#      done
+#    controller uses to inject source and manage the user process. A shared token
+#    lives in a Secret named "<release>-agent-token" (key "token") that both the
+#    controller and the warm-pool pods read.
 agentAuth:
+  # -- Generate the token and create the "<release>-agent-token" Secret in BOTH
+  #    the release namespace (read by the controller) and namespaces.apps (read
+  #    by the warm-pool pods), with the same value, so the control API is
+  #    authenticated out of the box. The value is looked up and reused on upgrade,
+  #    so it is stable. Set to false to manage the Secret yourself (create it with
+  #    the same value in both namespaces).
+  autoGenerate: true
   # -- Fail closed: the agent refuses the control API (inject/stop/status/logs)
-  #    when no token is configured, instead of serving it unauthenticated to the
-  #    untrusted workload sharing the pod. Only enable together with the Secret
-  #    above, or deploys will fail. Health/info probes stay unauthenticated.
+  #    when NO token is configured, instead of serving it unauthenticated to the
+  #    untrusted workload sharing the pod. With autoGenerate on a token is always
+  #    present, so this is defense-in-depth. Health/info probes stay open.
   require: false
 
 # -- Bring-your-own base-image validation. When enabled (default), the


### PR DESCRIPTION
Finishes #45 for the v0.4.3 release. Adds a chart-managed `<release>-agent-token` Secret (`agentAuth.autoGenerate`, default **true**) created with a matching, upgrade-stable value in both the release namespace and `namespaces.apps`, so the in-sandbox agent control API is authenticated **by default** (the controller and warm-pool pods already read this Secret). `autoGenerate: false` opts out. Verified with `helm template` (matching tokens in both namespaces) and `helm lint`.

Closes #45.