### PR TITLE
fix: security & performance quick-wins from the review backlog

### DIFF
--- a/cmd/vibed-workerd-loader/main.go
+++ b/cmd/vibed-workerd-loader/main.go
@@ -36,8 +36,15 @@ func main() {
 	flag.StringVar(&compatDate, "compat-date", "2024-01-01", "workerd compatibilityDate applied to every worker.")
 	flag.IntVar(&portBase, "port-base", 9100, "First port assigned to app sockets.")
 	flag.StringVar(&reloadCmd, "reload-cmd", "", "Shell command run after each config change to reload workerd (e.g. send SIGHUP). Empty = no-op (workerd auto-watches its config).")
-	flag.StringVar(&token, "token", os.Getenv("VIBED_AGENT_TOKEN"), "Bearer token required on the control API. Defaults to $VIBED_AGENT_TOKEN.")
+	flag.StringVar(&token, "token", "", "Bearer token required on the control API. Defaults to $VIBED_AGENT_TOKEN.")
 	flag.Parse()
+	// Fall back to the env var AFTER parsing: a non-empty flag default is
+	// rendered verbatim by the flag package on -h and on any parse error, which
+	// would dump the live control-API token to stderr where the log pipeline
+	// scrapes it.
+	if token == "" {
+		token = os.Getenv("VIBED_AGENT_TOKEN")
+	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 

--- a/internal/controller/vibedapp_controller.go
+++ b/internal/controller/vibedapp_controller.go
@@ -30,8 +30,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/vibed-project/vibeD/internal/meter"
@@ -148,6 +150,14 @@ type Reconciler struct {
 	Meter meter.Sink
 }
 
+// maxConcurrentReconciles is the controller's worker count. Reconcile blocks a
+// worker for the whole synchronous /inject HTTP call (up to 60s), so the
+// controller-runtime default of 1 lets one slow injection stall every app.
+// Injection is I/O-bound, so a small pool restores concurrency without
+// overwhelming the API server or warm pools; tune up if deploy latency degrades
+// under churn.
+const maxConcurrentReconciles = 4
+
 // SetupWithManager registers the reconciler with the manager. The
 // SandboxClaim watch ensures status changes on the claim
 // (agent-sandbox binding a pod, the pod becoming Ready) wake the
@@ -161,11 +171,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	claimGVKType.SetGroupVersionKind(SandboxClaimGVK)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&vibedv1.VibedApp{}, builder.WithPredicates()).
+		// GenerationChangedPredicate drops the reconciles triggered by our own
+		// Status().Update writes (status is a subresource, so it does not bump
+		// metadata.generation): the SandboxClaim watch and RequeueAfter already
+		// cover status-driven progression, so those extra passes are pure churn.
+		For(&vibedv1.VibedApp{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			claimGVKType,
 			handler.EnqueueRequestsFromMapFunc(claimToVibedApp),
 		).
+		// Bound the blast radius of the synchronous /inject call in Reconcile
+		// (up to 60s): with the controller-runtime default of one worker, a
+		// single slow injection stalls every other app's reconcile.
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Named("vibedapp").
 		Complete(r)
 }

--- a/internal/deployer/helpers.go
+++ b/internal/deployer/helpers.go
@@ -145,6 +145,10 @@ func FetchPodLogs(ctx context.Context, clientset kubernetes.Interface, namespace
 
 	var logLines []string
 	scanner := bufio.NewScanner(stream)
+	// Tolerate long log lines: the default 64KB scanner buffer triggers
+	// bufio.ErrTooLong and silently truncates. Mirror the streaming path
+	// (internal/deploy/logs.go).
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		logLines = append(logLines, scanner.Text())
 	}

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -726,15 +726,23 @@ func handleArtifactShareLink(orch *orchestrator.Orchestrator, artifactID string,
 
 	var expiresIn time.Duration
 	if body.ExpiresIn != "" {
-		// Support "7d" as shorthand for 7 days
+		// Support "7d" as shorthand for 7 days. A non-empty but unparseable
+		// value must be a 400: silently leaving expiresIn=0 mints a PERMANENT
+		// link when the caller asked for a time-limited one (fail-open on a
+		// security control).
 		s := body.ExpiresIn
+		var err error
 		if strings.HasSuffix(s, "d") {
-			days := strings.TrimSuffix(s, "d")
-			if d, err := time.ParseDuration(days + "h"); err == nil {
+			var d time.Duration
+			if d, err = time.ParseDuration(strings.TrimSuffix(s, "d") + "h"); err == nil {
 				expiresIn = d * 24
 			}
 		} else {
-			expiresIn, _ = time.ParseDuration(s)
+			expiresIn, err = time.ParseDuration(s)
+		}
+		if err != nil {
+			writeError(w, fmt.Errorf("invalid expires_in %q (use e.g. \"24h\" or \"7d\")", body.ExpiresIn), http.StatusBadRequest)
+			return
 		}
 	}
 

--- a/internal/mcp/tools_users.go
+++ b/internal/mcp/tools_users.go
@@ -69,8 +69,13 @@ type listDepartmentsOutput struct {
 func registerListDepartmentsTool(server *mcp.Server, userStore store.UserStore) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "list_departments",
-		Description: "List all departments in vibeD.",
+		Description: "List all departments in vibeD. Requires admin role.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, input listDepartmentsInput) (*mcp.CallToolResult, *listDepartmentsOutput, error) {
+		// MCP has no transport-level RBAC, so this per-handler check is the only
+		// gate — mirror the sibling admin tools (list_users, create_department).
+		if !vibedauth.IsAdmin(ctx) {
+			return nil, nil, fmt.Errorf("admin access required")
+		}
 		depts, err := userStore.ListDepartments(ctx)
 		if err != nil {
 			return nil, nil, err

--- a/internal/meter/meter.go
+++ b/internal/meter/meter.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // Event is one usage record.
@@ -39,11 +39,23 @@ type nop struct{}
 
 func (nop) Record(context.Context, Event) {}
 
-var eventsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+// eventsTotal is registered on BOTH the default Prometheus registry (the API
+// process's /metrics serves it → deploy/delete events) and controller-runtime's
+// registry (the controller's /metrics serves only that → app.ready/app.stopped
+// lifecycle events). Registering on the default registry alone — what promauto
+// did — left the controller-emitted events incrementing a counter no endpoint
+// exposed. Each process serves exactly one of the two endpoints, so a given
+// event is counted once.
+var eventsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "vibed",
 	Name:      "usage_events_total",
 	Help:      "Usage events by kind and tenant.",
 }, []string{"kind", "tenant"})
+
+func init() {
+	prometheus.MustRegister(eventsTotal)
+	ctrlmetrics.Registry.MustRegister(eventsTotal)
+}
 
 // Prometheus returns a Sink that counts events by kind and tenant (tenant id,
 // not name, to bound cardinality; the single-tenant default reports "default").

--- a/internal/runneragent/source.go
+++ b/internal/runneragent/source.go
@@ -96,6 +96,13 @@ func extractEntry(dir string, hdr *tar.Header, r io.Reader) error {
 	}
 	dest := filepath.Join(dir, clean)
 
+	// Defense-in-depth: mirror the post-join filepath.Rel containment the agent's
+	// sibling writeFiles applies, so a crafted entry can never resolve outside
+	// dir even if the prefix check above is bypassed by a future path form.
+	if rel, err := filepath.Rel(dir, dest); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("illegal tar entry path %q escapes extraction dir", hdr.Name)
+	}
+
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		if err := os.MkdirAll(dest, 0o755); err != nil {

--- a/internal/storage/router.go
+++ b/internal/storage/router.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"sync"
 
@@ -103,8 +104,10 @@ func (r *UserStorageRouter) resolve(ctx context.Context) Storage {
 
 	stg, err := r.createUserStorage(userID, cfg)
 	if err != nil {
-		// On error, fall back to default (don't crash)
-		fmt.Printf("WARNING: failed to create per-user storage for %q: %v (falling back to default)\n", userID, err)
+		// On error, fall back to default (don't crash). Route through slog (not
+		// stdout, which bypasses level filtering) and omit the raw error: a
+		// custom/refactored resolver's error could carry secret material.
+		slog.Warn("failed to create per-user storage; falling back to default", "userID", userID)
 		return r.fallback
 	}
 


### PR DESCRIPTION
Batch of small, high-confidence fixes from the security/performance review backlog. Each is independent; all verified with `go build ./...`, `go vet`, and the existing unit tests (`runneragent`, `meter`, `controller` all green).

## Security

| Issue | Fix |
| --- | --- |
| #54 | `vibed-workerd-loader` no longer defaults `-token` to `$VIBED_AGENT_TOKEN` — Go's flag package renders a default in `-h`/usage/parse-error output, dumping the live control-API token to stderr where the log pipeline scrapes it. Defaults to empty; falls back to the env var after `flag.Parse()`. |
| #58 | Creating a share link with a non-empty but unparseable `expires_in` (e.g. `"7 days"`, `"1w"`) now returns **400** instead of silently leaving the duration at `0` (= no expiry). The old behavior minted a *permanent* public link when the caller asked for a time-limited one — a fail-open on a security control. |
| #53 | `list_departments` MCP tool gains the `IsAdmin` gate its siblings (`list_users`, `create_department`, `get_user`) already have. MCP has no transport-level RBAC, so the per-handler check is the only defense against org-structure enumeration. |
| #65 | Per-user storage creation failures now log via `slog.Warn` (userID + static message) instead of `fmt.Printf` to stdout with the raw `%v` — stdout bypasses level filtering and a refactored/custom resolver error could carry secret material. |
| #64 | `runneragent.extractEntry` mirrors the `filepath.Rel` containment assertion the sibling `writeFiles` applies, so a crafted tar entry can never resolve outside the extraction dir. Defense-in-depth (no working escape today; symlinks are already rejected). |

## Performance

| Issue | Fix |
| --- | --- |
| #68 | Controller `MaxConcurrentReconciles` set to 4. `Reconcile` blocks a worker for the whole synchronous `/inject` call (up to 60s); with the controller-runtime default of one worker, a single slow injection stalls every other app's reconcile. |
| #69 | `GenerationChangedPredicate` added to the primary `VibedApp` watch, dropping the reconciles triggered by the controller's own `Status().Update` writes. The SandboxClaim watch + `RequeueAfter` already cover status-driven progression. |
| #67 | The usage-metering counter is now registered on **both** the default registry (API process → `deploy`/`delete`) and controller-runtime's registry (controller → `app.ready`/`app.stopped`). It was promauto-only, so the controller's endpoint — which serves only `ctrlmetrics.Registry` — never exposed the lifecycle events. Each process serves one endpoint, so nothing is double-counted. |
| #78 | The non-streaming `get_artifact_logs` path sets a 1MB `bufio.Scanner` buffer (mirroring the streaming path), so log lines >64KB stop being silently truncated by `bufio.ErrTooLong`. |

Closes #54, #58, #53, #65, #64, #68, #69, #67, #78.

> Note: `internal/frontend/handler.go` is pre-existing not-gofmt-clean (space-indented import block, unrelated to this change); left untouched to keep the diff minimal. Worth a separate `gofmt` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
