### PR TITLE
fix: enforce suspension for static-API-key users via one canonical ID [#48, #63]

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -135,6 +135,20 @@ func SkipAuthPaths(authMiddleware func(http.Handler) http.Handler) func(http.Han
 	}
 }
 
+// apiKeyUserID is the canonical user ID for a static API key. The verifier
+// (context identity), the auto-provisioned store record, and the role map all
+// derive the ID from this one function so they cannot desync — the desync
+// (verifier used key.Name while the record was stored under "apikey-"+key.Name)
+// is exactly what made the suspended-user check miss the record and fail open.
+// The prefix namespaces static keys away from OIDC subjects. An empty name
+// yields an empty ID, preserving the "no identity" behavior for a nameless key.
+func apiKeyUserID(name string) string {
+	if name == "" {
+		return ""
+	}
+	return "apikey-" + name
+}
+
 // apiKeyVerifier returns a TokenVerifier that validates tokens against configured API keys.
 // If userStore is non-nil, it auto-provisions users on first authentication.
 func apiKeyVerifier(keys []config.APIKeyConf, userStore store.UserStore, logger *slog.Logger) mcpauth.TokenVerifier {
@@ -155,7 +169,7 @@ func apiKeyVerifier(keys []config.APIKeyConf, userStore store.UserStore, logger 
 				return &mcpauth.TokenInfo{
 					Scopes:     key.Scopes,
 					Expiration: time.Now().Add(24 * time.Hour),
-					UserID:     key.Name,
+					UserID:     apiKeyUserID(key.Name),
 				}, nil
 			}
 		}
@@ -184,7 +198,7 @@ func apiKeyVerifier(keys []config.APIKeyConf, userStore store.UserStore, logger 
 
 // autoProvisionAPIKeyUser creates a user record on first API key authentication.
 func autoProvisionAPIKeyUser(ctx context.Context, userStore store.UserStore, key config.APIKeyConf, logger *slog.Logger) {
-	userID := "apikey-" + key.Name
+	userID := apiKeyUserID(key.Name)
 	if _, err := userStore.GetUser(ctx, userID); err == nil {
 		return // user already exists
 	}
@@ -322,8 +336,10 @@ func remoteIPTrusted(remoteAddr string, trusted []*net.IPNet) bool {
 	return false
 }
 
-// BuildRoleMap creates a mapping from user ID (APIKey Name) to role.
-// Users without an explicit role default to "user".
+// BuildRoleMap creates a mapping from the canonical API-key user ID
+// (apiKeyUserID) to role, matching the identity the verifier puts in the
+// context so RoleMiddleware's lookup hits. Users without an explicit role
+// default to "user".
 func BuildRoleMap(keys []config.APIKeyConf) map[string]string {
 	m := make(map[string]string, len(keys))
 	for _, k := range keys {
@@ -331,7 +347,7 @@ func BuildRoleMap(keys []config.APIKeyConf) map[string]string {
 		if role == "" {
 			role = "user"
 		}
-		m[k.Name] = role
+		m[apiKeyUserID(k.Name)] = role
 	}
 	return m
 }

--- a/internal/auth/suspend_test.go
+++ b/internal/auth/suspend_test.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vibed-project/vibeD/internal/config"
+	"github.com/vibed-project/vibeD/pkg/api"
+)
+
+// fakeUserStore is a minimal store.UserStore for auth tests: only user CRUD is
+// meaningful; the department methods satisfy the interface.
+type fakeUserStore struct{ users map[string]*api.User }
+
+func newFakeUserStore() *fakeUserStore { return &fakeUserStore{users: map[string]*api.User{}} }
+
+var errNoUser = errors.New("user not found")
+
+func (f *fakeUserStore) GetUser(_ context.Context, id string) (*api.User, error) {
+	if u, ok := f.users[id]; ok {
+		return u, nil
+	}
+	return nil, errNoUser
+}
+func (f *fakeUserStore) CreateUser(_ context.Context, u *api.User) error {
+	f.users[u.ID] = u
+	return nil
+}
+func (f *fakeUserStore) UpdateUser(_ context.Context, u *api.User) error {
+	f.users[u.ID] = u
+	return nil
+}
+func (f *fakeUserStore) GetUserByName(context.Context, string) (*api.User, error) {
+	return nil, errNoUser
+}
+func (f *fakeUserStore) ListUsers(context.Context, string) ([]api.User, error) { return nil, nil }
+func (f *fakeUserStore) GetUserByAPIKeyHash(context.Context, string) (*api.User, error) {
+	return nil, errNoUser
+}
+func (f *fakeUserStore) CreateDepartment(context.Context, *api.Department) error { return nil }
+func (f *fakeUserStore) GetDepartment(context.Context, string) (*api.Department, error) {
+	return nil, errNoUser
+}
+func (f *fakeUserStore) GetDepartmentByName(context.Context, string) (*api.Department, error) {
+	return nil, errNoUser
+}
+func (f *fakeUserStore) ListDepartments(context.Context) ([]api.Department, error) { return nil, nil }
+func (f *fakeUserStore) UpdateDepartment(context.Context, *api.Department) error   { return nil }
+func (f *fakeUserStore) DeleteDepartment(context.Context, string) error            { return nil }
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// TestApiKeyUserID_Canonical: the role map keys on the same canonical ID the
+// verifier emits, so RoleMiddleware's lookup can't miss.
+func TestApiKeyUserID_Canonical(t *testing.T) {
+	if got := apiKeyUserID("contractor"); got != "apikey-contractor" {
+		t.Errorf("apiKeyUserID(contractor) = %q, want apikey-contractor", got)
+	}
+	if got := apiKeyUserID(""); got != "" {
+		t.Errorf("apiKeyUserID(empty) = %q, want empty (no identity)", got)
+	}
+	rm := BuildRoleMap([]config.APIKeyConf{{Name: "contractor", Role: "admin"}})
+	if rm["apikey-contractor"] != "admin" {
+		t.Errorf("role map = %v, want key apikey-contractor -> admin", rm)
+	}
+}
+
+// TestSuspendedStaticKeyUser_Denied is the #48 regression guard: a suspended
+// static-key user must get 401. Before the canonical-ID fix, the suspended
+// record (stored as apikey-<name>) was never found by the check (which looked
+// up key.Name), so a suspended contractor kept full access.
+func TestSuspendedStaticKeyUser_Denied(t *testing.T) {
+	const key = "s3cr3t"
+	cfg := config.AuthConfig{
+		Enabled: true, Mode: "apikey",
+		APIKeys: []config.APIKeyConf{{Key: key, Name: "contractor"}},
+	}
+
+	serve := func(store *fakeUserStore) *httptest.Server {
+		mw, _, err := Build(cfg, store, discardLogger())
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		return httptest.NewServer(mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})))
+	}
+	call := func(srv *httptest.Server) int {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/artifacts", nil)
+		req.Header.Set("Authorization", "Bearer "+key)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	suspended := newFakeUserStore()
+	suspended.users["apikey-contractor"] = &api.User{ID: "apikey-contractor", Name: "contractor", Status: "suspended"}
+	sSrv := serve(suspended)
+	defer sSrv.Close()
+	if code := call(sSrv); code != http.StatusUnauthorized {
+		t.Errorf("suspended static-key user: got %d, want 401", code)
+	}
+
+	// Control: an active user (auto-provisioned on first auth) is allowed.
+	active := serve(newFakeUserStore())
+	defer active.Close()
+	if code := call(active); code != http.StatusOK {
+		t.Errorf("active static-key user: got %d, want 200", code)
+	}
+}


### PR DESCRIPTION
## The bug

Suspending a static-API-key user was a **no-op** — a suspended contractor kept full access indefinitely.

Root cause is an identity-namespace desync across three places that all had to agree:

| Site | ID used |
| --- | --- |
| verifier (request context) | `key.Name` |
| auto-provisioned store record | `"apikey-" + key.Name` |
| role map key | `key.Name` |

The suspended-user check does `GetUser(contextID)` = `GetUser(key.Name)`, which misses the `apikey-`-prefixed record, so the suspend branch never fires (fail-open). Same root cause desynced role resolution (#63).

## The fix

One canonical ID via `apiKeyUserID(name)`, used for **all three** — verifier identity, provisioned record ID, and role-map key — so they can't drift apart again. The `apikey-` prefix still namespaces static keys away from OIDC subjects (which use the raw `sub` as both context ID and record ID); an empty name yields an empty ID, preserving the "no identity" behavior for a nameless key.

Closes #48. Closes #63.

## Verification

New regression test (`suspend_test.go`, runs by default — not gated behind the `integration` tag): a suspended static-key user now gets **401** (was 200), an active one still **200**, and the role map keys on the canonical ID. Full `internal/auth` suite green; `go build ./...`, `go vet`, gofmt clean.

## ⚠️ Breaking change (static keys only)

A static-key user's canonical ID is now `apikey-<name>` **everywhere, including artifact ownership**. Artifacts deployed by a static-key user *before* this change were owned under the bare `key.Name` and won't match afterward. If you relied on static-key owner-scoping with pre-existing artifacts, re-key ownership or redeploy. OIDC and no-auth users are unaffected.

## Not included (same #48 issue text, deferred)

- "Clear the stored `api_key_hash` on suspend/delete" — that's a store/user-management change (runtime-generated keys), separate from this auth-path fix; worth a follow-up so a suspended user's *runtime* key also stops working immediately.
- OAuth-passthrough's spoofable ID has no provisioned record by design (proxy-trusted identity), so suspension doesn't apply there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
