### PR TITLE
fix: fail closed on artifact ownership when auth is enabled [#49]

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -675,14 +675,27 @@ func (o *Orchestrator) ListTargets() []api.TargetInfo {
 	return o.detector.ListTargets()
 }
 
+// authEnabled reports whether authentication is configured on. The ownership
+// bypass keys on this explicit flag — NOT on an empty context user — so a
+// request that carries no identity while auth is enabled (e.g. MCP over stdio,
+// which doesn't propagate a bearer token into the context) fails closed instead
+// of being treated as trusted.
+func (o *Orchestrator) authEnabled() bool {
+	return o.cfg != nil && o.cfg.Auth.Enabled
+}
+
 // checkOwnership verifies that the current user can read the artifact.
 // Allows: owner, admin, or users in the SharedWith list.
 // Returns ErrNotFound (not Forbidden) to avoid leaking artifact existence to non-owners.
-// When auth is disabled (ownerID is empty), all ownership checks pass.
+// With auth disabled all checks pass (dev/no-auth); with auth enabled a caller
+// with no identity is denied.
 func (o *Orchestrator) checkOwnership(ctx context.Context, artifact *api.Artifact) error {
+	if !o.authEnabled() {
+		return nil // Auth disabled — no ownership enforcement
+	}
 	ownerID := vibedauth.UserIDFromContext(ctx)
 	if ownerID == "" {
-		return nil // Auth disabled — no ownership enforcement
+		return &api.ErrNotFound{ArtifactID: artifact.ID} // auth on, no identity → fail closed
 	}
 	if vibedauth.IsAdmin(ctx) {
 		return nil // Admin can access everything
@@ -702,9 +715,12 @@ func (o *Orchestrator) checkOwnership(ctx context.Context, artifact *api.Artifac
 // checkWriteOwnership verifies that the current user can modify the artifact.
 // Only owner and admin can write — shared users have read-only access.
 func (o *Orchestrator) checkWriteOwnership(ctx context.Context, artifact *api.Artifact) error {
+	if !o.authEnabled() {
+		return nil // Auth disabled
+	}
 	ownerID := vibedauth.UserIDFromContext(ctx)
 	if ownerID == "" {
-		return nil // Auth disabled
+		return &api.ErrNotFound{ArtifactID: artifact.ID} // auth on, no identity → fail closed
 	}
 	if vibedauth.IsAdmin(ctx) {
 		return nil // Admin can modify everything

--- a/internal/orchestrator/ownership_test.go
+++ b/internal/orchestrator/ownership_test.go
@@ -1,0 +1,94 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	vibedauth "github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/config"
+	"github.com/vibed-project/vibeD/pkg/api"
+)
+
+func orchWithAuth(enabled bool) *Orchestrator {
+	return &Orchestrator{cfg: &config.Config{Auth: config.AuthConfig{Enabled: enabled}}}
+}
+
+func ctxUser(id string) context.Context {
+	return vibedauth.WithUserID(context.Background(), id)
+}
+
+func ctxAdmin(id string) context.Context {
+	return vibedauth.WithRole(vibedauth.WithUserID(context.Background(), id), "admin")
+}
+
+// TestCheckOwnership_FailsClosedWhenAuthEnabled is the #49 regression guard: an
+// identity-less caller (e.g. MCP over stdio, which doesn't propagate a token)
+// must NOT be able to read another user's artifact when auth is enabled. The
+// bug keyed the bypass on an empty owner ID, which treated "no identity" as
+// trusted.
+func TestCheckOwnership_FailsClosedWhenAuthEnabled(t *testing.T) {
+	art := &api.Artifact{ID: "app-1", OwnerID: "alice", SharedWith: []string{"carol"}}
+
+	// Auth disabled → no enforcement (dev/no-auth mode).
+	if err := orchWithAuth(false).checkOwnership(context.Background(), art); err != nil {
+		t.Errorf("auth disabled: want allow, got %v", err)
+	}
+
+	on := orchWithAuth(true)
+	cases := []struct {
+		name    string
+		ctx     context.Context
+		allowed bool
+	}{
+		{"anonymous (auth on) denied", context.Background(), false}, // the fix
+		{"owner allowed", ctxUser("alice"), true},
+		{"non-owner denied", ctxUser("mallory"), false},
+		{"shared user allowed", ctxUser("carol"), true},
+		{"admin allowed", ctxAdmin("someadmin"), true},
+	}
+	for _, c := range cases {
+		err := on.checkOwnership(c.ctx, art)
+		if c.allowed && err != nil {
+			t.Errorf("%s: want allow, got %v", c.name, err)
+		}
+		if !c.allowed && err == nil {
+			t.Errorf("%s: want deny, got allow", c.name)
+		}
+	}
+}
+
+func TestCheckWriteOwnership_FailsClosedWhenAuthEnabled(t *testing.T) {
+	art := &api.Artifact{ID: "app-1", OwnerID: "alice", SharedWith: []string{"carol"}}
+	on := orchWithAuth(true)
+
+	cases := []struct {
+		name    string
+		ctx     context.Context
+		allowed bool
+	}{
+		{"anonymous (auth on) denied", context.Background(), false}, // the fix
+		{"owner allowed", ctxUser("alice"), true},
+		{"non-owner denied", ctxUser("mallory"), false},
+		{"shared user cannot write", ctxUser("carol"), false}, // read-only sharing
+		{"admin allowed", ctxAdmin("someadmin"), true},
+	}
+	for _, c := range cases {
+		err := on.checkWriteOwnership(c.ctx, art)
+		if c.allowed && err != nil {
+			t.Errorf("%s: want allow, got %v", c.name, err)
+		}
+		if !c.allowed && err == nil {
+			t.Errorf("%s: want deny, got allow", c.name)
+		}
+	}
+
+	// Auth disabled → allow even anonymously.
+	if err := orchWithAuth(false).checkWriteOwnership(context.Background(), art); err != nil {
+		t.Errorf("auth disabled: want allow, got %v", err)
+	}
+	// Unowned artifact + authenticated user → writable.
+	unowned := &api.Artifact{ID: "app-2", OwnerID: ""}
+	if err := on.checkWriteOwnership(ctxUser("alice"), unowned); err != nil {
+		t.Errorf("unowned artifact: want allow for authed user, got %v", err)
+	}
+}


### PR DESCRIPTION
## The bug (cross-user IDOR)

`get_artifact_logs`, `rollback_artifact`, and `list_versions` call the orchestrator directly, whose ownership checks returned `nil` (allow) whenever the context user was empty — treating "no identity" as "auth disabled / trusted". Over MCP **stdio** (or any transport that doesn't propagate `TokenInfo` into the context), `UserIDFromContext` is empty even with auth enabled, so **any caller could read any artifact's logs and roll any artifact back to a chosen version by ID.**

## The fix (fail closed at the root)

Key the ownership bypass on the explicit `cfg.Auth.Enabled` flag instead of on an empty owner ID:

- auth **off** → no enforcement (dev / no-auth mode, unchanged);
- auth **on** + a caller with **no identity** → **deny** (`ErrNotFound`, which also avoids leaking artifact existence).

Fixing the two shared checks (`checkOwnership`, `checkWriteOwnership`) covers **every** owner-scoped orchestrator method — not just the three reported tools — so the class of bug is closed, not three instances of it. The `Orchestrator` already holds `cfg`, so no new plumbing.

Closes #49.

## Verification

White-box tests for both checks: anonymous-denied-when-auth-on (the fix), owner, non-owner, shared read-only, admin, and unowned-writable. `go build ./...`, `go vet`, gofmt clean; non-integration suites for orchestrator/mcp/deploy/frontend green.

## ⚠️ Behavior change

With auth enabled, an **unauthenticated context** (e.g. MCP stdio carrying no token) is now **denied** owner-scoped reads/writes rather than served. Deployments that expose stdio *and* enable auth should be aware. Auth-disabled (dev) and authenticated HTTP callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
