### PR TITLE
chore(release): prep docs + chart for v0.4.4

### DIFF
--- a/deploy/helm/vibed/Chart.yaml
+++ b/deploy/helm/vibed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vibed
 description: Workload orchestrator for GenAI-generated artifacts
 type: application
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.4.4
+appVersion: "0.4.4"
 keywords:
   - mcp
   - genai

--- a/deploy/helm/vibed/values.yaml
+++ b/deploy/helm/vibed/values.yaml
@@ -258,11 +258,11 @@ workerd:
 #    (repo:tag) — bump the tag with each release (CI publishes these to GHCR).
 #    Override with your own registry/tag in production.
 warmPools:
-  node-24:      { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-runner-node:0.4.1",         replicas: 50, resources: { requests: { cpu: 100m, memory: 128Mi }, limits: { cpu: 500m, memory: 512Mi } } }
-  python-313:   { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-runner-python:0.4.1",       replicas: 50, resources: { requests: { cpu: 100m, memory: 128Mi }, limits: { cpu: 500m, memory: 512Mi } } }
-  go-123:       { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-template-go-123:0.4.1",     replicas: 20, resources: { requests: { cpu: 200m, memory: 256Mi }, limits: { cpu: "1", memory: 768Mi } } }
-  base-al2023:  { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-template-base-al2023:0.4.1", replicas: 30, resources: { requests: { cpu: 250m, memory: 256Mi }, limits: { cpu: "1", memory: 1Gi } } }
-  static-nginx: { enabled: true,  lane: fast,    image: "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.1", replicas: 30, resources: { requests: { cpu: 50m, memory: 32Mi }, limits: { cpu: 200m, memory: 128Mi } } }
+  node-24:      { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-runner-node:0.4.4",         replicas: 50, resources: { requests: { cpu: 100m, memory: 128Mi }, limits: { cpu: 500m, memory: 512Mi } } }
+  python-313:   { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-runner-python:0.4.4",       replicas: 50, resources: { requests: { cpu: 100m, memory: 128Mi }, limits: { cpu: 500m, memory: 512Mi } } }
+  go-123:       { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-template-go-123:0.4.4",     replicas: 20, resources: { requests: { cpu: 200m, memory: 256Mi }, limits: { cpu: "1", memory: 768Mi } } }
+  base-al2023:  { enabled: true,  lane: general, image: "ghcr.io/vibed-project/vibed-template-base-al2023:0.4.4", replicas: 30, resources: { requests: { cpu: 250m, memory: 256Mi }, limits: { cpu: "1", memory: 1Gi } } }
+  static-nginx: { enabled: true,  lane: fast,    image: "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.4", replicas: 30, resources: { requests: { cpu: 50m, memory: 32Mi }, limits: { cpu: 200m, memory: 128Mi } } }
 
 config:
   server:

--- a/docs/docs/configuration/authentication.md
+++ b/docs/docs/configuration/authentication.md
@@ -51,9 +51,14 @@ auth:
 
 - Keys can be literal values or resolved from environment variables using the `env:` prefix
 - Keys also support `file:/path/to/token` to read tokens from files
-- Each key has a human-readable `name` used as the user identity (UserID) for ownership
+- Each key has a human-readable `name`; the owning user identity (UserID) is `apikey-<name>`, and a user record is auto-provisioned under that ID on first authentication
 - Optional `scopes` restrict what the key can do (empty = unrestricted)
 - Constant-time comparison prevents timing attacks
+- **Suspension is enforced:** setting a key's user record `status: suspended` immediately revokes access on the next request (401)
+
+:::caution Upgrading to v0.4.4
+The canonical user ID for a static API key is now `apikey-<name>` everywhere — request identity, the provisioned user record, the role map, and **artifact ownership**. Before v0.4.4 the raw `name` was used for ownership, so artifacts deployed by a static-key user on an older version are owned under the bare `name` and won't match after upgrade. If you rely on static-key owner-scoping with pre-existing artifacts, re-key their ownership or redeploy. OIDC and no-auth users are unaffected.
+:::
 
 ### OIDC Mode
 

--- a/docs/docs/configuration/custom-base-images.md
+++ b/docs/docs/configuration/custom-base-images.md
@@ -24,7 +24,7 @@ Your image must satisfy the contract below. The simplest path is to start `FROM`
 
 ```dockerfile
 # Stage 1: grab a statically-linked vibed-agent (or COPY one you've vendored).
-FROM ghcr.io/vibed-project/vibed-runner-node:0.4.1 AS agent
+FROM ghcr.io/vibed-project/vibed-runner-node:0.4.4 AS agent
 
 # Stage 2: your hardened base.
 FROM your-registry/hardened-node:24

--- a/docs/docs/configuration/egress-control.md
+++ b/docs/docs/configuration/egress-control.md
@@ -19,6 +19,10 @@ NetworkPolicy: a sandbox may egress ONLY to the proxy — there is no direct int
 - Sandboxes get `HTTP(S)_PROXY` pointed at Squid, so their HTTP libraries route through it.
 - For every connection, Squid asks **`vibed-egress-authz`**, which maps the source pod IP → the owning `VibedApp` → its `egress.allowedHosts`, and allows or denies (default-deny). vibeD's **system hosts** (e.g. the S3/MinIO source store) are always allowed so the agent can still pull source. Denials are logged.
 
+:::note Metadata / DNS-rebinding protection
+The allow-list authorizes a **hostname**, but the decision to connect is also enforced on the **resolved IP** — so an allow-listed domain whose DNS answers `169.254.169.254` (the cloud metadata endpoint) or a link-local/loopback address is still refused. `vibed-egress-authz` rejects a host that resolves to a metadata/link-local range, and Squid additionally denies these ranges by the IP it actually connects to. In the production posture (`storage.tarball.backend: s3`, external object store) Squid also denies RFC1918 / IPv6-ULA ranges — there's no legitimate in-cluster egress target. With the in-cluster `served` source store those private ranges stay reachable so source injection keeps working.
+:::
+
 ## Declaring an app's allowed hosts
 
 Per app, via the deploy metadata or the MCP tool:

--- a/docs/docs/deployment/production-guide.md
+++ b/docs/docs/deployment/production-guide.md
@@ -22,9 +22,9 @@ CI builds and pushes all component images to GHCR: `vibed`, `vibed-controller`, 
 ## 2. Production values
 
 ```yaml
-image: { repository: ghcr.io/vibed-project/vibed, tag: "v0.4.1", pullPolicy: IfNotPresent }
-controller: { image: { tag: "v0.4.1" }, domain: apps.example.com }
-router:     { image: { tag: "v0.4.1" } }
+image: { repository: ghcr.io/vibed-project/vibed, tag: "v0.4.4", pullPolicy: IfNotPresent }
+controller: { image: { tag: "v0.4.4" }, domain: apps.example.com }
+router:     { image: { tag: "v0.4.4" } }
 
 # Sandbox isolation
 runtime:

--- a/docs/docs/mcp-tools/list-versions.md
+++ b/docs/docs/mcp-tools/list-versions.md
@@ -30,14 +30,14 @@ List all version snapshots for a deployed artifact, ordered by version number. E
       "version": 1,
       "status": "running",
       "url": "http://my-portfolio.default.localhost:31080",
-      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.1",
+      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.4",
       "created_at": "2026-03-14T10:00:00Z"
     },
     {
       "version": 2,
       "status": "running",
       "url": "http://my-portfolio.default.localhost:31080",
-      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.1",
+      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.4",
       "created_at": "2026-03-14T12:30:00Z"
     }
   ]


### PR DESCRIPTION
Docs + chart prep for the **v0.4.4** security release (rolls up #86/#87/#88/#89, all merged).

## Docs
- **authentication.md** — corrects the now-wrong statement that a key's `name` is the ownership identity (it's `apikey-<name>`), documents that **suspension is now enforced**, and adds a v0.4.4 **upgrade caution** for the artifact-ownership ID change (#48).
- **egress-control.md** — documents the **metadata / DNS-rebinding protection** (#46): an allow-listed host that resolves to `169.254.169.254` or a link-local/loopback address is refused on the resolved IP; RFC1918/ULA are denied in the production (s3) posture.
- Refreshed stale `v0.4.1` image-tag examples → `v0.4.4` (production-guide, custom-base-images, list-versions).

## Chart / values
- `Chart.yaml` version/appVersion → `0.4.4` (the release workflow injects these from the tag anyway; this just keeps the repo self-consistent).
- **`warmPools` template image tags `0.4.1` → `0.4.4`** — ⚠️ **the important one.** They were stuck at `0.4.1`, so a v0.4.4 chart would run sandboxes on the *old* `vibed-agent`, missing the agent-side security fixes (agent-control-API auth #45, the runneragent zip-slip guard #64). The release build publishes `0.4.4` template images; this points warm pools at them.

Verified: `helm template` renders (image refs now at 0.4.4); docusaurus admonitions balanced.

## Not included (flag for the release cut)
- `web/package.json` is at `0.4.1` (the dashboard's own package version) — cosmetic, left as-is; bump if you keep it in sync.
- Cutting the release itself is `git tag v0.4.4 && git push origin v0.4.4`, which triggers `release.yaml` (images + SBOM + chart + GitHub release). That's an outward publish — leaving the actual tag push to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
