### PR TITLE
fix: make the config validator consult the plugin registry

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -573,9 +573,12 @@ func validate(cfg *Config) error {
 		}
 	}
 
-	validStoreBackends := map[string]bool{"memory": true, "configmap": true, "sqlite": true}
-	if !validStoreBackends[cfg.Store.Backend] {
-		return fmt.Errorf("store.backend must be one of: memory, configmap, sqlite (got %q)", cfg.Store.Backend)
+	// Built-in backends are always valid; an out-of-tree backend registered in
+	// the store registry (via pkg/plugin) is accepted via the injected lister.
+	// See extension.go.
+	builtinStoreBackends := []string{"memory", "configmap", "sqlite"}
+	if !contains(builtinStoreBackends, cfg.Store.Backend) && !listerHas(storeBackendLister, cfg.Store.Backend) {
+		return fmt.Errorf("store.backend must be one of: %s (got %q)", availableNames(builtinStoreBackends, storeBackendLister), cfg.Store.Backend)
 	}
 
 	if cfg.Store.Backend == "sqlite" && cfg.Store.SQLite.Path == "" {
@@ -588,9 +591,12 @@ func validate(cfg *Config) error {
 
 	// Validate auth config
 	if cfg.Auth.Enabled {
-		validModes := map[string]bool{"apikey": true, "oauth": true, "oidc": true, "": true}
-		if !validModes[cfg.Auth.Mode] {
-			return fmt.Errorf("auth.mode must be one of: apikey, oauth, oidc (got %q)", cfg.Auth.Mode)
+		// Built-in modes (including "" = the apikey default) are always valid; an
+		// out-of-tree mode registered in the auth registry (via pkg/plugin) is
+		// accepted via the injected lister. See extension.go.
+		builtinAuthModes := []string{"apikey", "oauth", "oidc", ""}
+		if !contains(builtinAuthModes, cfg.Auth.Mode) && !listerHas(authModeLister, cfg.Auth.Mode) {
+			return fmt.Errorf("auth.mode must be one of: %s (got %q)", availableNames([]string{"apikey", "oauth", "oidc"}, authModeLister), cfg.Auth.Mode)
 		}
 		if (cfg.Auth.Mode == "apikey" || cfg.Auth.Mode == "oauth" || cfg.Auth.Mode == "") && len(cfg.Auth.APIKeys) == 0 {
 			return fmt.Errorf("at least one API key (or proxy secret) is required when auth.mode is %q", cfg.Auth.Mode)

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"sort"
+	"strings"
+)
+
+// Out-of-tree providers registered through the pkg/plugin extension API add
+// store backends and auth modes to the internal/store and internal/auth
+// registries at init() time. The config validator must then accept their
+// store.backend / auth.mode values — but config is a leaf package that must NOT
+// import those registries (internal/auth already imports config, so importing
+// it back would create a cycle). The server therefore injects small lister
+// functions here before Load runs. When they are unset — bare config tests, or
+// tools that never boot a server — only the built-in names are valid, so
+// validation stays strict by default.
+var (
+	storeBackendLister func() []string
+	authModeLister     func() []string
+)
+
+// SetStoreBackendLister installs a function returning every store backend known
+// to the registry (built-in + out-of-tree). The server calls it once before
+// LoadConfig; passing nil clears it.
+func SetStoreBackendLister(f func() []string) { storeBackendLister = f }
+
+// SetAuthModeLister installs a function returning every registered auth mode.
+// The server calls it once before LoadConfig; passing nil clears it.
+func SetAuthModeLister(f func() []string) { authModeLister = f }
+
+// contains reports whether want is in the built-in allow-list.
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// listerHas reports whether the injected lister knows want. A nil lister (never
+// injected) knows nothing, so only the built-in allow-list applies.
+func listerHas(f func() []string, want string) bool {
+	if f == nil {
+		return false
+	}
+	for _, got := range f() {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+// availableNames renders "builtin ∪ registered" as a sorted, comma-separated
+// list for a validation error message, so an operator sees that an
+// out-of-tree-registered backend/mode is in fact available. The empty mode (the
+// apikey default) is never surfaced.
+func availableNames(builtin []string, lister func() []string) string {
+	set := make(map[string]bool, len(builtin))
+	for _, b := range builtin {
+		set[b] = true
+	}
+	if lister != nil {
+		for _, n := range lister() {
+			if n != "" {
+				set[n] = true
+			}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for n := range set {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}

--- a/internal/config/extension_test.go
+++ b/internal/config/extension_test.go
@@ -1,0 +1,80 @@
+package config
+
+import "testing"
+
+// The config validator must accept store backends / auth modes registered out
+// of tree via pkg/plugin once the server injects the registry listers, while
+// staying strict by default. Before this, a build that registered an
+// out-of-tree backend/mode fataled at config load because the validator ran
+// against the built-in allow-list before the registry was consulted.
+
+func TestValidate_StoreBackend_RegistryAware(t *testing.T) {
+	t.Cleanup(func() { SetStoreBackendLister(nil); SetAuthModeLister(nil) })
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("default config should load: %v", err)
+	}
+
+	// Strict by default: an unregistered backend is rejected.
+	cfg.Store.Backend = "customstore"
+	if err := validate(cfg); err == nil {
+		t.Fatal("an out-of-tree store.backend must be rejected when no lister is injected")
+	}
+
+	// Accepted once the registry reports it (as LoadConfig wires up).
+	SetStoreBackendLister(func() []string { return []string{"memory", "configmap", "sqlite", "customstore"} })
+	if err := validate(cfg); err != nil {
+		t.Fatalf("a registered store.backend must be accepted: %v", err)
+	}
+
+	// A still-unknown backend is rejected even with a lister present.
+	cfg.Store.Backend = "nosuchstore"
+	if err := validate(cfg); err == nil {
+		t.Fatal("an unregistered backend must still be rejected")
+	}
+}
+
+func TestValidate_AuthMode_RegistryAware(t *testing.T) {
+	t.Cleanup(func() { SetStoreBackendLister(nil); SetAuthModeLister(nil) })
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("default config should load: %v", err)
+	}
+	cfg.Auth.Enabled = true
+	cfg.Auth.Mode = "customauth"
+
+	// Strict by default: rejected before the registry is consulted.
+	if err := validate(cfg); err == nil {
+		t.Fatal("an out-of-tree auth.mode must be rejected when no lister is injected")
+	}
+
+	// Accepted once registered. A non-built-in mode (not apikey/oauth/"") carries
+	// no API keys, so validation must pass with none configured.
+	SetAuthModeLister(func() []string { return []string{"apikey", "oauth", "oidc", "customauth"} })
+	if err := validate(cfg); err != nil {
+		t.Fatalf("a registered auth.mode must be accepted: %v", err)
+	}
+}
+
+func TestValidate_BuiltinsValidWithoutListers(t *testing.T) {
+	// Regression guard: the built-in backends/modes must stay valid when no
+	// lister is injected (bare config load, tools that never boot a server).
+	SetStoreBackendLister(nil)
+	SetAuthModeLister(nil)
+
+	for _, backend := range []string{"memory", "configmap", "sqlite"} {
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("default config should load: %v", err)
+		}
+		if backend == "sqlite" {
+			cfg.Store.SQLite.Path = "/tmp/vibed.db"
+		}
+		cfg.Store.Backend = backend
+		if err := validate(cfg); err != nil {
+			t.Fatalf("built-in store.backend=%s must validate without a lister: %v", backend, err)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,6 +97,14 @@ func Main() {
 // bootstrap without importing internal/config: assign the result with := and it
 // never has to name the config type.
 func LoadConfig(path string) (*config.Config, error) {
+	// Teach the config validator about store backends and auth modes registered
+	// out of tree via pkg/plugin. Their provider init()s have already run by the
+	// time any binary reaches this call, so the registries are populated;
+	// without this the validator would reject a registered store.backend /
+	// auth.mode before the registry is ever consulted. Built-ins remain valid
+	// when nothing is registered.
+	config.SetStoreBackendLister(store.Backends)
+	config.SetAuthModeLister(vibedauth.Providers)
 	return config.Load(path)
 }
 


### PR DESCRIPTION
Completes the **`pkg/plugin`** extension surface: the config validator now consults the plugin registry, so out-of-tree builds that register additional store backends / auth modes can actually select them.

## The bug
`pkg/plugin` lets out-of-tree builds register store backends and auth modes in the `internal/store` / `internal/auth` registries. But `config.Load`'s validator checked `store.backend` / `auth.mode` against a hardcoded built-in allow-list **before** the registry was consulted, so a registered backend/mode fataled at config load:

```
invalid config: store.backend must be one of: memory, configmap, sqlite (got "...")
```

## The fix
`config` is a leaf package (`internal/auth` imports it, so it can't import the registries back). It now exposes injectable listers (`SetStoreBackendLister` / `SetAuthModeLister`); `pkg/server`'s `LoadConfig` wires them to `store.Backends` / `auth.Providers` before `config.Load`. The validator accepts **built-ins ∪ registered names**, and stays **strict by default** — with no lister injected (bare config tests, tools that never boot a server), only the built-ins are valid.

## Tests
`internal/config/extension_test.go`: an unregistered backend/mode is rejected; a registered one validates; built-ins stay valid with no lister. `go build ./...`, `go vet`, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
