### PR TITLE
docs(site): refresh for v0.4.4 (release label + list_departments/share-link behavior)

### DIFF
--- a/docs/docs/mcp-tools/create-share-link.md
+++ b/docs/docs/mcp-tools/create-share-link.md
@@ -14,7 +14,7 @@ Requires [authentication](/docs/configuration/authentication) and the SQLite sto
 |-----------|------|----------|-------------|
 | `artifact_id` | string | Yes | ID of the artifact to create a share link for |
 | `password` | string | No | Optional password to protect the link |
-| `expires_in` | string | No | Expiration duration (e.g. `24h`, `7d`). Empty means no expiration. |
+| `expires_in` | string | No | Expiration duration (e.g. `24h`, `7d`). Empty means no expiration; a non-empty value that can't be parsed as a duration is rejected with `400` (it is not silently treated as "no expiration"). |
 
 ## Example
 

--- a/docs/docs/mcp-tools/overview.md
+++ b/docs/docs/mcp-tools/overview.md
@@ -43,7 +43,7 @@ When a **user store** is configured, vibeD also registers user- and department-a
 |------|-------------|--------|
 | [`list_users`](./user-management#list_users) | List users, optionally filtered by `department_id` | Admin role |
 | [`get_user`](./user-management#get_user) | Fetch one user by `user_id` | Admin, or the caller viewing themselves |
-| [`list_departments`](./user-management#list_departments) | List all departments | Any authenticated caller |
+| [`list_departments`](./user-management#list_departments) | List all departments | Admin role |
 | [`create_department`](./user-management#create_department) | Create a department by `name` | Admin role |
 
 See [User & department management](./user-management) for input schemas, responses, and the role checks each tool enforces.

--- a/docs/docs/mcp-tools/user-management.md
+++ b/docs/docs/mcp-tools/user-management.md
@@ -12,10 +12,9 @@ one department creator — vibeD does not create or delete users through MCP.
 These tools are only registered when the configured [`store` backend](../configuration/config-reference.md) implements user persistence. The bundled `sqlite` backend does; the `configmap` (and in-memory) backends do **not**. With a non-user store the four tools are simply absent from the MCP tool list. An out-of-tree store that implements the same interface enables them too.
 :::
 
-Access is role-scoped. `list_users`, `create_department` require the caller to
-hold the `admin` role. `get_user` lets a regular user read their own record and
-an admin read anyone's. `list_departments` is available to any authenticated
-caller.
+Access is role-scoped. `list_users`, `list_departments`, and `create_department`
+require the caller to hold the `admin` role. `get_user` lets a regular user read
+their own record and an admin read anyone's.
 
 ## Tools
 
@@ -23,7 +22,7 @@ caller.
 |------|------|-------------|
 | [`list_users`](#list_users) | admin | List all users, optionally filtered by department |
 | [`get_user`](#get_user) | self / admin | Get one user's details |
-| [`list_departments`](#list_departments) | any | List all departments |
+| [`list_departments`](#list_departments) | admin | List all departments |
 | [`create_department`](#create_department) | admin | Create a department |
 
 ---
@@ -115,7 +114,7 @@ exist".
 
 ## list_departments
 
-List all departments. Available to any authenticated caller.
+List all departments. Requires the `admin` role.
 
 ### Input Schema
 
@@ -141,7 +140,8 @@ Takes no parameters.
 }
 ```
 
-An empty registry returns `{"departments": []}`.
+An empty registry returns `{"departments": []}`. A non-admin caller receives an
+`admin access required` error.
 
 ---
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
           {
             // Current release, shown left of the GitHub link. Bump on release.
             href: 'https://github.com/vibed-project/vibeD/releases',
-            label: 'v0.4.2',
+            label: 'v0.4.4',
             position: 'right',
           },
           {


### PR DESCRIPTION
Refreshes the docs website for **v0.4.4**.

## Stale release link
The navbar "current release" chip was stuck at **v0.4.2** (it links to `/releases`; the label just wasn't bumped for 0.4.3/0.4.4). Now **v0.4.4**.

## Content that changed in v0.4.4
- **`list_departments` now requires admin** (was "any authenticated caller"). Fixed in `user-management.md` (prose, the tools table, and the section) and the `overview.md` tools table.
- **Share links:** `create-share-link.md` now documents that a non-empty but **unparseable `expires_in`** is rejected with **400** — it is no longer silently treated as "no expiration."

## Already covered (earlier docs refresh, merged)
Egress metadata/DNS-rebind protection (`egress-control.md`), the `apikey-<name>` ownership identity + enforced suspension (`authentication.md`), and the `v0.4.4` image-tag examples (production-guide / custom-base-images / list-versions).

## Checks
- Swept the site: no remaining `v0.4.1/0.4.2/0.4.3` references (agent-sandbox's `v0.4.5+` dep and historical "removed in v0.4.1" notes are correctly left).
- No broken internal doc links.
- "18 MCP tools" count unchanged and still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
