### PR TITLE
Harden runner-agent source fetch: SSRF guard + decompression-bomb caps

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/vibed-project/vibeD/internal/tarsafe"
 	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
 )
 
@@ -162,7 +163,12 @@ func scanTarball(ctx context.Context, r io.Reader) (*scan, error) {
 		hasExt:    map[string]bool{},
 	}
 
-	tr := tar.NewReader(gz)
+	// Bound cumulative uncompressed bytes. The classifier only reads headers
+	// (plus a capped package.json), but tar.Next still inflates the data it
+	// skips, so a decompression bomb would burn CPU/memory here; the budget
+	// aborts it. Entry count is capped too.
+	tr := tar.NewReader(tarsafe.NewLimitedReader(gz, tarsafe.MaxUncompressedBytes))
+	entries := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -173,6 +179,10 @@ func scanTarball(ctx context.Context, r io.Reader) (*scan, error) {
 		}
 		if err != nil {
 			return nil, fmt.Errorf("read tarball: %w", err)
+		}
+		entries++
+		if entries > tarsafe.MaxEntries {
+			return nil, fmt.Errorf("tarball has too many entries (> %d)", tarsafe.MaxEntries)
 		}
 		// Normalize: strip any "./" prefix and skip pure-directory entries
 		// for the markers map (we still record extensions for asset files).

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -39,14 +39,23 @@ func IsBlocked(addr netip.Addr) bool {
 		addr.IsUnspecified()
 }
 
+// awsIMDSv6 is AWS's instance-metadata endpoint over IPv6. It lives in IPv6 ULA
+// (fc00::/7), which IsLinkLocalOrLoopback otherwise allows for in-cluster
+// traffic, so it must be denied explicitly — otherwise the IPv4 metadata IP is
+// blocked (it is link-local) while its IPv6 sibling leaks. A single well-known
+// host, not a range, so denying it does not touch legitimate cluster traffic.
+var awsIMDSv6 = netip.MustParseAddr("fd00:ec2::254")
+
 // IsLinkLocalOrLoopback reports whether addr is loopback, link-local (including
 // the 169.254.169.254 metadata endpoint and IPv6 fe80::/10), the unspecified
-// address, or multicast — ranges that are NEVER a legitimate egress
-// destination. Unlike IsBlocked it deliberately does NOT include private/RFC1918
-// or IPv6 ULA, which are valid in-cluster service addresses (e.g. an in-cluster
-// source store the egress authz must keep allowing). Use this where blanket
-// private-range denial would break legitimate internal traffic; use IsBlocked
-// for an untrusted-facing dial where nothing internal is a valid target.
+// address, multicast, or a known cloud metadata endpoint reachable via an
+// otherwise-allowed range (AWS IMDS over IPv6) — ranges that are NEVER a
+// legitimate egress destination. Unlike IsBlocked it deliberately does NOT
+// include private/RFC1918 or IPv6 ULA generally, which are valid in-cluster
+// service addresses (e.g. an in-cluster source store the egress authz must keep
+// allowing). Use this where blanket private-range denial would break legitimate
+// internal traffic; use IsBlocked for an untrusted-facing dial where nothing
+// internal is a valid target.
 func IsLinkLocalOrLoopback(addr netip.Addr) bool {
 	if !addr.IsValid() {
 		return true
@@ -57,7 +66,8 @@ func IsLinkLocalOrLoopback(addr netip.Addr) bool {
 		addr.IsLinkLocalMulticast() ||
 		addr.IsInterfaceLocalMulticast() ||
 		addr.IsMulticast() ||
-		addr.IsUnspecified()
+		addr.IsUnspecified() ||
+		addr.WithZone("") == awsIMDSv6
 }
 
 // hostResolvesTo reports whether host resolves to at least one address that

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -79,11 +79,12 @@ func TestIsLinkLocalOrLoopback(t *testing.T) {
 		{"127.0.0.1", true},       // loopback
 		{"::1", true},             // IPv6 loopback
 		{"::ffff:169.254.169.254", true},
+		{"fd00:ec2::254", true}, // AWS IMDS over IPv6 (ULA, but a metadata host)
 		// Must NOT be flagged — legitimate in-cluster / private targets.
 		{"10.0.0.5", false},   // RFC1918 (e.g. a ClusterIP)
 		{"172.16.3.4", false}, // RFC1918
 		{"192.168.1.1", false},
-		{"fd00::1", false}, // IPv6 ULA
+		{"fd00::1", false}, // IPv6 ULA (in-cluster) stays allowed
 		{"8.8.8.8", false}, // public
 	}
 	for _, c := range cases {

--- a/internal/runneragent/source.go
+++ b/internal/runneragent/source.go
@@ -6,11 +6,17 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
+
+	"github.com/vibed-project/vibeD/internal/netguard"
+	"github.com/vibed-project/vibeD/internal/tarsafe"
 )
 
 // MaxTarballBytes caps the on-the-wire tarball size at 50 MB, matching
@@ -24,11 +30,70 @@ const MaxTarballBytes = 50 * 1024 * 1024
 // http.Client with a short connect timeout — callers can swap it in tests.
 type SourceFetcher struct {
 	Client *http.Client
+	// dialGuard classifies an IP the fetcher must refuse to connect to. nil uses
+	// the production guard (netguard.IsLinkLocalOrLoopback). Overridable by
+	// in-package tests that must reach a loopback httptest server.
+	dialGuard func(netip.Addr) bool
 }
 
-// NewSourceFetcher returns a fetcher with sensible production timeouts.
+func (f *SourceFetcher) blocked(ip netip.Addr) bool {
+	if f.dialGuard != nil {
+		return f.dialGuard(ip)
+	}
+	return netguard.IsLinkLocalOrLoopback(ip)
+}
+
+func allowedScheme(s string) bool { return s == "http" || s == "https" }
+
+// NewSourceFetcher returns a fetcher with production timeouts and an SSRF guard.
+// It connects only over http/https and refuses to dial loopback, link-local, or
+// the cloud metadata endpoint (169.254.169.254). The address is checked at
+// connect time (net.Dialer.Control, after DNS resolution) so a rebind to a
+// blocked IP cannot slip past a name-based allow-list. Private/RFC1918 is
+// deliberately allowed: the source tarball is served from an in-cluster host
+// (internal/tarball/served.go), so blanket private-range denial would break
+// every deploy — this mirrors the boundary the egress authz enforces.
 func NewSourceFetcher() *SourceFetcher {
-	return &SourceFetcher{Client: &http.Client{Timeout: 60 * time.Second}}
+	f := &SourceFetcher{}
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("source dial: bad address %q: %w", address, err)
+			}
+			ip, err := netip.ParseAddr(host)
+			if err != nil {
+				return fmt.Errorf("source dial: unresolved address %q", host)
+			}
+			if f.blocked(ip) {
+				return fmt.Errorf("source dial to %s is not allowed", ip)
+			}
+			return nil
+		},
+	}
+	f.Client = &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			// This path faces untrusted input: ignore env proxies so the dial
+			// guard inspects the real target IP, not a proxy's.
+			Proxy:                 nil,
+			DialContext:           dialer.DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("source fetch: stopped after 10 redirects")
+			}
+			if !allowedScheme(req.URL.Scheme) {
+				return fmt.Errorf("source fetch: redirect to disallowed scheme %q", req.URL.Scheme)
+			}
+			return nil
+		},
+	}
+	return f
 }
 
 // Fetch downloads sourceURL and extracts the resulting gzipped tarball into
@@ -42,6 +107,9 @@ func (f *SourceFetcher) Fetch(ctx context.Context, sourceURL, dir string) error 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
 	if err != nil {
 		return fmt.Errorf("build source request: %w", err)
+	}
+	if !allowedScheme(req.URL.Scheme) {
+		return fmt.Errorf("source url scheme %q is not allowed (http or https only)", req.URL.Scheme)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -62,7 +130,17 @@ func (f *SourceFetcher) Fetch(ctx context.Context, sourceURL, dir string) error 
 	}
 	defer gz.Close()
 
-	tr := tar.NewReader(gz)
+	budget := int64(tarsafe.MaxUncompressedBytes)
+
+	// Two independent caps defeat a decompression bomb. (1) tarsafe.LimitedReader
+	// bounds bytes read from the gzip stream (headers + data tar.Next skips), so
+	// a tiny gzip can't burn unbounded CPU/memory. (2) `remaining` (below) bounds
+	// bytes actually WRITTEN across all entries — the load-bearing one, because a
+	// PAX/GNU sparse entry materializes hole zeros without reading the gzip
+	// stream, so a read-side cap alone would let it write unbounded zeros.
+	tr := tar.NewReader(tarsafe.NewLimitedReader(gz, budget))
+	remaining := budget
+	entries := 0
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -71,7 +149,14 @@ func (f *SourceFetcher) Fetch(ctx context.Context, sourceURL, dir string) error 
 		if err != nil {
 			return fmt.Errorf("read tarball: %w", err)
 		}
-		if err := extractEntry(dir, hdr, tr); err != nil {
+		entries++
+		if entries > tarsafe.MaxEntries {
+			return fmt.Errorf("tarball has too many entries (> %d)", tarsafe.MaxEntries)
+		}
+		if hdr.Size > budget {
+			return fmt.Errorf("tar entry %q is too large (%d bytes)", hdr.Name, hdr.Size)
+		}
+		if err := extractEntry(dir, hdr, tr, &remaining); err != nil {
 			return err
 		}
 	}
@@ -89,7 +174,7 @@ func (f *SourceFetcher) Fetch(ctx context.Context, sourceURL, dir string) error 
 // extractEntry writes a single tar entry under dir. Symlinks and absolute /
 // parent-escaping paths are rejected; the agent runs untrusted code but the
 // extraction itself must not be the attack surface.
-func extractEntry(dir string, hdr *tar.Header, r io.Reader) error {
+func extractEntry(dir string, hdr *tar.Header, r io.Reader, remaining *int64) error {
 	clean := filepath.Clean(hdr.Name)
 	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("illegal tar entry path %q", hdr.Name)
@@ -116,9 +201,19 @@ func extractEntry(dir string, hdr *tar.Header, r io.Reader) error {
 		if err != nil {
 			return fmt.Errorf("open %s: %w", dest, err)
 		}
-		if _, err := io.Copy(f, r); err != nil {
+		// Copy at most (remaining+1) bytes so we can detect an overrun: CopyN
+		// materializes sparse-hole zeros just like a real read, so this counts the
+		// bytes hitting disk. A single write past the shared budget aborts.
+		rem := *remaining
+		n, cerr := io.CopyN(f, r, rem+1)
+		*remaining = rem - n
+		if cerr != nil && cerr != io.EOF {
 			_ = f.Close()
-			return fmt.Errorf("write %s: %w", dest, err)
+			return fmt.Errorf("write %s: %w", dest, cerr)
+		}
+		if n > rem {
+			_ = f.Close()
+			return fmt.Errorf("write %s: %w", dest, tarsafe.ErrTooLarge)
 		}
 		if err := f.Close(); err != nil {
 			return fmt.Errorf("close %s: %w", dest, err)

--- a/internal/runneragent/source_test.go
+++ b/internal/runneragent/source_test.go
@@ -8,12 +8,23 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/vibed-project/vibeD/internal/tarsafe"
 )
+
+// loopbackFetcher relaxes the SSRF dial guard so a test can reach a loopback
+// httptest server; production NewSourceFetcher refuses loopback/link-local.
+func loopbackFetcher() *SourceFetcher {
+	f := NewSourceFetcher()
+	f.dialGuard = func(netip.Addr) bool { return false }
+	return f
+}
 
 // tarballFromMap builds a deterministic gzipped tarball whose entries match
 // files (relative path → content). Useful for end-to-end SourceURL tests.
@@ -57,7 +68,7 @@ func TestSourceFetcherExtractsTarball(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
-	if err := NewSourceFetcher().Fetch(context.Background(), srv.URL, dir); err != nil {
+	if err := loopbackFetcher().Fetch(context.Background(), srv.URL, dir); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 
@@ -83,7 +94,7 @@ func TestSourceFetcherRejectsPathEscape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := NewSourceFetcher().Fetch(context.Background(), srv.URL, t.TempDir())
+	err := loopbackFetcher().Fetch(context.Background(), srv.URL, t.TempDir())
 	if err == nil || !strings.Contains(err.Error(), "illegal tar entry") {
 		t.Fatalf("expected illegal-tar-entry error, got %v", err)
 	}
@@ -95,9 +106,119 @@ func TestSourceFetcherRejectsNon2xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := NewSourceFetcher().Fetch(context.Background(), srv.URL, t.TempDir())
+	err := loopbackFetcher().Fetch(context.Background(), srv.URL, t.TempDir())
 	if err == nil || !strings.Contains(err.Error(), "403") {
 		t.Fatalf("expected 403 surfaced, got %v", err)
+	}
+}
+
+func TestSourceFetcherBlocksMetadataAndLoopbackDial(t *testing.T) {
+	// The production guard refuses the cloud metadata endpoint and loopback at
+	// dial time — Control fires before any connection is made.
+	for _, target := range []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://127.0.0.1:1/x.tgz",
+	} {
+		err := NewSourceFetcher().Fetch(context.Background(), target, t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "not allowed") {
+			t.Fatalf("Fetch(%s): want a blocked-dial error, got %v", target, err)
+		}
+	}
+}
+
+func TestSourceFetcherGuardAllowsPrivateBlocksMetadata(t *testing.T) {
+	// In-cluster RFC1918 (the served tarball store) must stay reachable; the
+	// metadata/link-local and loopback endpoints must not.
+	f := NewSourceFetcher()
+	for _, ok := range []string{"10.0.0.5", "192.168.1.1", "172.16.0.9"} {
+		if f.blocked(netip.MustParseAddr(ok)) {
+			t.Errorf("guard blocked in-cluster private address %s", ok)
+		}
+	}
+	for _, bad := range []string{"169.254.169.254", "127.0.0.1", "::1", "fe80::1", "fd00:ec2::254"} {
+		if !f.blocked(netip.MustParseAddr(bad)) {
+			t.Errorf("guard failed to block %s", bad)
+		}
+	}
+}
+
+// TestExtractEntryEnforcesCumulativeWriteBudget checks the load-bearing
+// decompression-bomb guard: bytes actually written are capped across entries.
+// This is what defeats PAX/GNU sparse entries, which materialize hole zeros
+// without reading the compressed stream, so a read-side cap alone misses them.
+func TestExtractEntryEnforcesCumulativeWriteBudget(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, name := range []string{"a.bin", "b.bin"} {
+		body := bytes.Repeat([]byte("x"), 100)
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(&buf)
+	dir := t.TempDir()
+	remaining := int64(150) // fits one 100-byte entry, not both
+	var err error
+	for {
+		hdr, e := tr.Next()
+		if e == io.EOF {
+			break
+		}
+		if e != nil {
+			t.Fatalf("next: %v", e)
+		}
+		if err = extractEntry(dir, hdr, tr, &remaining); err != nil {
+			break
+		}
+	}
+	if err == nil || !strings.Contains(err.Error(), "exceeds limit") {
+		t.Fatalf("expected a cumulative write-budget error, got %v", err)
+	}
+}
+
+func TestSourceFetcherRejectsNonHTTPScheme(t *testing.T) {
+	for _, u := range []string{"file:///etc/passwd", "ftp://example.com/x.tgz", "gopher://x/1"} {
+		err := NewSourceFetcher().Fetch(context.Background(), u, t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "scheme") {
+			t.Fatalf("Fetch(%s): want a scheme error, got %v", u, err)
+		}
+	}
+}
+
+// bombHeaderTarball builds a gzipped stream with a single tar header that
+// declares a huge size but has no matching body — enough for tar.Reader.Next to
+// surface the oversized declared size so the per-entry cap rejects it without
+// inflating hundreds of MB.
+func bombHeaderTarball(t *testing.T, declaredSize int64) []byte {
+	t.Helper()
+	var raw bytes.Buffer
+	tw := tar.NewWriter(&raw)
+	_ = tw.WriteHeader(&tar.Header{Name: "bomb.bin", Mode: 0o644, Size: declaredSize, Typeflag: tar.TypeReg})
+	// Deliberately skip the body + Close: only the 512-byte header is needed.
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+	return gz.Bytes()
+}
+
+func TestSourceFetcherRejectsDecompressionBomb(t *testing.T) {
+	bomb := bombHeaderTarball(t, tarsafe.MaxUncompressedBytes+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	err := loopbackFetcher().Fetch(context.Background(), srv.URL, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected the oversized entry to be rejected, got %v", err)
 	}
 }
 
@@ -118,6 +239,7 @@ func TestInjectWithSourceURL(t *testing.T) {
 		AppPort:   8080,
 		StopGrace: 200 * time.Millisecond,
 	})
+	a.Fetcher.dialGuard = func(netip.Addr) bool { return false } // reach the loopback tarServer
 	t.Cleanup(func() { a.stopProcess() })
 
 	srv := httptest.NewServer(a.handler())

--- a/internal/tarsafe/tarsafe.go
+++ b/internal/tarsafe/tarsafe.go
@@ -1,0 +1,59 @@
+// Package tarsafe bounds the work an extractor performs on an untrusted gzipped
+// tarball, defeating decompression bombs: a small compressed input (well under
+// a compressed-size cap) can inflate to many gigabytes, exhausting a sandbox's
+// disk/inodes. Callers wrap the decompressed stream in a LimitedReader that
+// aborts once cumulative output exceeds MaxUncompressedBytes, and enforce
+// MaxEntries in their tar loop.
+package tarsafe
+
+import (
+	"errors"
+	"io"
+)
+
+const (
+	// MaxUncompressedBytes caps the total inflated size of a tarball. Source
+	// tarballs are capped at 50 MB compressed; this allows ~10x expansion, far
+	// under the tens of GB a bomb would otherwise write.
+	MaxUncompressedBytes = 512 * 1024 * 1024
+
+	// MaxEntries caps the number of tar entries, bounding the inode exhaustion
+	// (and loop-count) amplification of an archive packed with many tiny or
+	// empty files that individually stay under the byte budget.
+	MaxEntries = 100_000
+)
+
+// ErrTooLarge is returned by a LimitedReader once its uncompressed byte budget
+// is exceeded.
+var ErrTooLarge = errors.New("tarsafe: uncompressed data exceeds limit")
+
+// ErrTooManyEntries is a suggested sentinel for callers that hit MaxEntries.
+var ErrTooManyEntries = errors.New("tarsafe: too many tar entries")
+
+// LimitedReader reads from R but returns ErrTooLarge once more than its initial
+// budget has been read in total. Unlike io.LimitReader it fails hard rather than
+// reporting a silent EOF, so an overrun aborts extraction instead of yielding a
+// truncated tree that looks complete.
+type LimitedReader struct {
+	R io.Reader
+	n int64 // bytes remaining before overrun; goes negative on the read that overflows
+}
+
+// NewLimitedReader caps cumulative reads from r at max bytes.
+func NewLimitedReader(r io.Reader, max int64) *LimitedReader {
+	return &LimitedReader{R: r, n: max}
+}
+
+func (l *LimitedReader) Read(p []byte) (int, error) {
+	if l.n < 0 {
+		return 0, ErrTooLarge
+	}
+	n, err := l.R.Read(p)
+	l.n -= int64(n)
+	if l.n < 0 {
+		// This read pushed the total past the budget; surface the bytes read so
+		// far alongside the hard error so the caller stops immediately.
+		return n, ErrTooLarge
+	}
+	return n, err
+}

--- a/internal/tarsafe/tarsafe_test.go
+++ b/internal/tarsafe/tarsafe_test.go
@@ -1,0 +1,48 @@
+package tarsafe
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestLimitedReader_WithinBudget(t *testing.T) {
+	lr := NewLimitedReader(strings.NewReader("hello world"), 100)
+	got, err := io.ReadAll(lr)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestLimitedReader_ExactBudgetIsNotAnError(t *testing.T) {
+	lr := NewLimitedReader(strings.NewReader("abcde"), 5)
+	got, err := io.ReadAll(lr)
+	if err != nil {
+		t.Fatalf("reading exactly the budget must not error: %v", err)
+	}
+	if string(got) != "abcde" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestLimitedReader_OverBudgetFailsHardAndEarly(t *testing.T) {
+	const budget = 1024
+	// A 4 MiB source; a decompression bomb is analogous but larger.
+	big := bytes.NewReader(make([]byte, 4<<20))
+	lr := NewLimitedReader(big, budget)
+
+	n, err := io.Copy(io.Discard, lr)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("want ErrTooLarge, got %v", err)
+	}
+	// It must abort near the budget, not drain the whole source (bounded by the
+	// budget plus at most one copy buffer).
+	if n >= 4<<20 {
+		t.Fatalf("reader drained the whole source (%d bytes); expected an early abort", n)
+	}
+}


### PR DESCRIPTION
The runner agent fetches an untrusted source tarball by URL and extracts it into the sandbox. This hardens both halves of that path.

## SSRF on the fetch (#52)

- Connect only over **http/https**; reject other schemes on the initial URL and on every redirect hop.
- Refuse to dial **loopback, link-local, and cloud metadata** endpoints, enforced at `net.Dialer.Control` — *after* DNS resolution and *before* connect — so a DNS rebind is caught at the actual dialed IP, and the guard applies to each redirect hop's dial automatically. Redirects capped; env proxies disabled.

**Deliberate deviation from the issue's suggested direction:** it proposed requiring https and blocking private ranges. Both would break every deploy — the tarball is served from an **in-cluster host over http with an RFC1918 ClusterIP** (`internal/tarball/served.go`), and blanket private denial is exactly the regression fixed in #87. So the guard allows private/RFC1918 and uses the same `netguard.IsLinkLocalOrLoopback` classifier the egress authz uses.

## Decompression bomb on the extraction (#51)

A ~1 MB gzip (under the 50 MB download cap) can inflate ~1000x. New `internal/tarsafe` bounds the work:

- A `LimitedReader` that **hard-fails** once cumulative *read* bytes exceed a 512 MB budget (used by both the extractor and the classifier's header scan).
- A per-entry declared-size cap and a 100k entry-count cap.
- Extraction additionally caps bytes **actually written** across all entries (`io.CopyN` against a shared budget). This is load-bearing: a read-side cap alone misses PAX/GNU **sparse** entries, which materialize hole zeros without reading the compressed stream and would otherwise write unbounded data to disk.

## Adversarial review caught two issues (both fixed here)

- **PAX sparse-file bypass (high):** the initial read-only cap let sparse entries write unbounded zeros. Fixed with the written-bytes cap above.
- **IPv6 metadata leak (medium):** AWS IMDS-over-IPv6 (`fd00:ec2::254`) sits in ULA, which the narrow guard allows for in-cluster traffic. `netguard.IsLinkLocalOrLoopback` now denies that specific host (helps the egress authz too).

## Testing

`gofmt`/`go vet`/`go build ./...` clean. New/updated tests: dial guard blocks metadata (v4 + v6)/loopback and allows RFC1918; non-http(s) schemes rejected; oversized and cumulative-over-budget entries rejected; `tarsafe` bounds reads; `netguard` blocks `fd00:ec2::254`. Existing extraction + classifier tests stay green.

Closes #51, #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)