### PR TITLE
docs: dev-first install path + agent-sandbox/Kata clarity; chart: warmPoolsEnabled guard

### DIFF
--- a/deploy/helm/vibed/templates/warmpools.yaml
+++ b/deploy/helm/vibed/templates/warmpools.yaml
@@ -8,6 +8,7 @@ These mirror templates/<name>/template.yaml but are values-driven so image
 refs / pool sizes / the RuntimeClass are environment-configurable.
 */ -}}
 {{- $root := . }}
+{{- if $root.Values.warmPoolsEnabled }}
 {{- range $name, $cfg := .Values.warmPools }}
 {{- if $cfg.enabled }}
 ---
@@ -122,5 +123,6 @@ spec:
     name: {{ $name }}
   updateStrategy:
     type: OnReplenish
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/vibed/values.yaml
+++ b/deploy/helm/vibed/values.yaml
@@ -252,6 +252,13 @@ workerd:
     tag: ""              # empty -> chart appVersion
     pullPolicy: IfNotPresent
 
+# -- Master switch for rendering the SandboxTemplate + SandboxWarmPool objects,
+#    which require the agent-sandbox *extensions* CRDs
+#    (extensions.agents.x-k8s.io). Set false to install the control plane before
+#    agent-sandbox is present, then flip true on `helm upgrade`. The per-pool
+#    `enabled` toggles below still apply when this is true.
+warmPoolsEnabled: true
+
 # -- Warm pools: one SandboxTemplate + SandboxWarmPool per language template
 #    (refactor.md §6.1), rendered into namespaces.apps. Set replicas to size
 #    each pool; image must embed vibed-agent. The image is a full ref

--- a/docs/docs/getting-started/first-deployment.md
+++ b/docs/docs/getting-started/first-deployment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # First Deployment

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -1,40 +1,76 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Installation
 
-vibeD ships as a Helm chart and runs on any Kubernetes 1.29+ cluster with a compatible node pool. For a laptop setup, see [Local development](local-dev.md) instead.
+This page installs vibeD on a real Kubernetes cluster (1.29+).
+
+:::tip Just trying it out?
+For a laptop / evaluation setup, use **[Local development](local-dev.md)** — a single `make dev` stands up kind, all dependencies, and vibeD. This page is for a shared or production cluster.
+:::
 
 ## Prerequisites
 
-1. **A Kubernetes cluster** (EKS/GKE/AKS or on-prem), 1.29+.
-2. **[agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) installed** (v0.4.5+). vibeD builds on its `Sandbox`, `SandboxTemplate`, `SandboxClaim`, and `SandboxWarmPool` CRDs and its controller. Install it before vibeD.
-3. **A Kata RuntimeClass** for the general lane — `kata-qemu` (works without nested virt) or `kata-fc` (Firecracker, needs KVM). The general lane runs user code in Kata microVMs.
-4. **A sandbox node pool** labeled `vibed.dev/sandbox-node: "true"` running `containerd` + `containerd-shim-kata-v2`. Firecracker (`kata-fc`) needs KVM (bare metal, `*.metal` on AWS, or nested-virt images on GCP); `kata-qemu` runs without it.
-5. **Object storage** (S3 or MinIO) for source tarballs in production — see [storage](../configuration/storage.md).
-6. **A DNS-01 capable DNS provider** (Cloudflare, Route53, …) for Caddy's wildcard TLS cert on `*.<your-domain>`.
+1. **Kubernetes 1.29+** (EKS/GKE/AKS or on-prem), with cluster-admin to install CRDs.
+2. **[agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) — core *and* extensions** (v0.4.5+). vibeD renders `SandboxTemplate` and `SandboxWarmPool` objects, so the **extensions** CRDs must exist before you install vibeD. [Step 1](#step-1--install-agent-sandbox) installs them.
+3. **A sandbox node pool** labeled `vibed.dev/sandbox-node: "true"`.
+4. *(General lane only)* **A Kata `RuntimeClass`** — see [The general lane and Kata](#the-general-lane-and-kata). Static sites and other fast-lane deploys do **not** need Kata.
+5. *(Production only)* **Object storage** (S3 or MinIO) for source tarballs, and a **DNS-01 capable DNS provider** for wildcard TLS — see [Going to production](#going-to-production).
 
-## Install
+## Step 1 — Install agent-sandbox
+
+vibeD depends on agent-sandbox's controller and CRDs — the **core** (`Sandbox`) **and** the **extensions** (`SandboxTemplate`, `SandboxClaim`, `SandboxWarmPool`). Apply the upstream release manifests (v0.4.5+ required; substitute the version you want):
+
+```bash
+VER=v0.4.5
+# core: controller + Sandbox CRD
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/$VER/manifest.yaml
+# extensions: SandboxTemplate / SandboxClaim / SandboxWarmPool CRDs + controller
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/$VER/extensions.yaml
+```
+
+Confirm the extension CRDs are registered before continuing:
+
+```bash
+kubectl get crd sandboxtemplates.extensions.agents.x-k8s.io \
+                sandboxwarmpools.extensions.agents.x-k8s.io
+```
+
+:::note
+The kind testbed wraps these same manifests in a Helm chart (`testbed/agent-sandbox/`) that `make dev` uses. On a real cluster the raw `kubectl apply` above is simplest.
+:::
+
+## Step 2 — Install vibeD
+
+vibeD ships as a Helm chart. The **minimal install** uses the in-cluster `served` source store and a ConfigMap metadata store — **no S3, no external database** — which is enough to evaluate on an unhardened cluster:
 
 ```bash
 helm install vibed deploy/helm/vibed/ \
   -n vibed-system --create-namespace \
-  --set controller.domain=apps.example.com \
-  --set config.storage.tarball.backend=s3 \
-  --set config.storage.tarball.s3.bucket=vibed-sources \
-  --set config.storage.tarball.s3.region=us-east-1
+  --set controller.domain=apps.example.com
 ```
 
-This installs the control plane (vibed, vibed-controller, vibed-router, Caddy) into `vibed-system` and the warm pools into the `vibed-apps` workloads namespace.
+This installs the control plane (vibed, vibed-controller, vibed-router, Caddy) into `vibed-system` and one `SandboxWarmPool` per enabled runtime into the `vibed-apps` namespace. See [Going to production](#going-to-production) for S3 and hardening.
 
-:::warning CRD upgrades
-The `VibedApp` CRD lives in the chart's `crds/` directory. Helm installs CRDs **only on first install and never on `helm upgrade`**. After upgrading to a version that changes the CRD schema, apply it manually:
+:::info Installing before agent-sandbox?
+If the agent-sandbox **extensions** CRDs aren't present yet, `helm install` fails with `no matches for kind "SandboxTemplate"`. Either do [Step 1](#step-1--install-agent-sandbox) first (recommended), or install the control plane alone and enable the pools once agent-sandbox is ready:
+
+```bash
+helm install vibed deploy/helm/vibed/ -n vibed-system --create-namespace \
+  --set controller.domain=apps.example.com --set warmPoolsEnabled=false
+# …install agent-sandbox (Step 1), then:
+helm upgrade vibed deploy/helm/vibed/ -n vibed-system --set warmPoolsEnabled=true
+```
+:::
+
+### CRD upgrades
+
+The `VibedApp` CRD ships in the chart's `crds/` directory. Helm installs it on first install but **never on `helm upgrade`**. After upgrading to a version that changes the CRD schema, re-apply it:
 
 ```bash
 kubectl apply -f deploy/helm/vibed/crds/vibed.dev_vibedapps.yaml
 ```
-:::
 
 ## Verify
 
@@ -43,10 +79,35 @@ kubectl get pods -n vibed-system            # control plane Running
 kubectl get sandboxwarmpool -n vibed-apps   # warm pools populated
 ```
 
-## Production essentials
+Then deploy something — see [First deployment](first-deployment.md).
 
-- **Source backend = `s3`.** The `served` backend (vibeD serves blobs from its own PVC) only works in dev. In production, sandboxes run under a restrictive NetworkPolicy with no cluster DNS, so the agent can only pull from a pre-signed S3/MinIO URL.
-- **Sandbox NetworkPolicy.** Set `runtime.sandboxNetworkPolicy: Unmanaged` and `networkPolicy.enabled: true` so vibeD owns a policy that permits exactly the control-plane → sandbox traffic plus DNS + S3 egress.
-- **Pin image tags** (not `latest`) and enable auth before exposing the API.
+## The general lane and Kata
 
-See the [configuration reference](../configuration/config-reference.md) for every value, and the [production guide](../deployment/production-guide.md) for the full hardened setup.
+vibeD has two lanes. The **fast lane** (static sites, workerd) runs in ordinary pods and needs no special runtime — a first static deploy works with nothing extra. The **general lane** (Node/Python/Go/custom images) runs user code in **Kata microVMs** for VM-level isolation, which needs:
+
+- A **Kata `RuntimeClass`** — `kata-qemu` (works without nested virt) or `kata-fc` (Firecracker, needs KVM). Select it with `runtime.defaultClass`.
+- Sandbox nodes running `containerd` + `containerd-shim-kata-v2`. `kata-fc` needs KVM (bare metal, AWS `*.metal`, or nested-virt images on GCP); `kata-qemu` does not.
+
+The easiest way to install Kata and register the RuntimeClasses is the [kata-deploy](https://github.com/kata-containers/kata-containers/tree/main/tools/packaging/kata-deploy) DaemonSet.
+
+Until a Kata RuntimeClass exists, run only the fast lane: set `warmPoolsEnabled=false` (or enable just `static-nginx`). Leaving `runtime.defaultClass: ""` runs general-lane pods **without** Kata isolation — the dev default, not for production.
+
+## Going to production
+
+The minimal install above is fine for an eval; a hardened deployment also needs:
+
+- **Source backend = `s3`.** The `served` backend only works while sandboxes have cluster DNS. In production sandboxes run under a restrictive NetworkPolicy with no cluster DNS, so the agent must pull a **pre-signed URL**:
+
+  ```bash
+  helm upgrade vibed deploy/helm/vibed/ -n vibed-system \
+    --set config.storage.tarball.backend=s3 \
+    --set config.storage.tarball.s3.bucket=vibed-sources \
+    --set config.storage.tarball.s3.region=us-east-1
+  ```
+
+- **Sandbox NetworkPolicy** — `runtime.sandboxNetworkPolicy: Unmanaged` + `networkPolicy.enabled: true`, so vibeD owns a policy that permits exactly the control-plane → sandbox traffic plus DNS + S3 egress.
+- **A Kata RuntimeClass** for the general lane (above).
+- **HTTPS** via Caddy's DNS-01 wildcard cert on `*.<your-domain>`.
+- **Pinned image tags** (not `latest`) and **auth enabled** before exposing the API.
+
+See the [configuration reference](../configuration/config-reference.md) and the [production guide](../deployment/production-guide.md) for the full hardened setup, plus [storage](../configuration/storage.md) for S3/MinIO details.

--- a/docs/docs/getting-started/local-dev.md
+++ b/docs/docs/getting-started/local-dev.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Local Development Setup

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -5,7 +5,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Getting Started',
-      items: ['getting-started/installation', 'getting-started/local-dev', 'getting-started/first-deployment'],
+      items: ['getting-started/local-dev', 'getting-started/first-deployment', 'getting-started/installation'],
     },
     {
       type: 'category',


### PR DESCRIPTION
From a getting-started dry run. The install page led with a production, S3-first `helm` command and never explained the agent-sandbox prerequisite, so a fresh install failed with `no matches for kind "SandboxTemplate"`.

## Docs
- Rewrite `getting-started/installation` into a real-cluster guide: point laptop users at **Local Development**, then **Step 1** install agent-sandbox (core **and** extensions — explicit `kubectl apply`, version note, CRD check), **Step 2** a **minimal no-S3 install** (served store + configmap), and a separate **Going to production** section for S3 + NetworkPolicy + Kata + HTTPS.
- Clarify **Kata is general-lane only** — static/fast-lane deploys need none — and link `kata-deploy` for installing the RuntimeClasses.
- Reorder Getting Started so **Local Development → First Deployment → Installation** (matches how people actually start).

## Chart
- Add a **`warmPoolsEnabled`** master switch (default `true`). Setting it `false` lets the control plane install *before* agent-sandbox's extension CRDs exist; `helm upgrade --set warmPoolsEnabled=true` once they're present. Documented in the install "installing before agent-sandbox?" note.

## Why the S3 change
Dev genuinely needs no S3: the default `served` tarball backend serves blobs from vibeD's own PVC. S3 is only required in production, where the locked-down sandbox NetworkPolicy removes cluster DNS so the agent must pull a pre-signed URL. The old page baked `--set …backend=s3…` into the primary example.

## Verified
`helm lint` passes; default renders all warm-pool objects and `warmPoolsEnabled=false` renders none; the Docusaurus build is clean (no broken links/anchors).

Addresses install-experience feedback from a manual dry run (no filed issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)