### PR TITLE
DX quick wins: profile-menu auto-close, go/base pool targets, Goose docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ KIND_RUNTIME := podman
 GHCR_IMAGE := ghcr.io/vibed-project/vibed
 RUNNER_PYTHON_IMAGE := localhost/vibed-runner-python:dev
 RUNNER_NODE_IMAGE := localhost/vibed-runner-node:dev
+RUNNER_GO_IMAGE := localhost/vibed-template-go-123:dev
+RUNNER_BASE_IMAGE := localhost/vibed-template-base-al2023:dev
 
 # Code generation
 CONTROLLER_GEN_VERSION := v0.18.0
@@ -28,6 +30,8 @@ TB_AGENT_SANDBOX := $(TESTBED)/agent-sandbox
         generate manifests controller-gen openapi-gen oapi-codegen \
         image load-image \
         runner-images runner-image-python runner-image-node load-runner-images \
+        runner-image-go runner-image-base load-runner-image-go load-runner-image-base \
+        enable-python-pool enable-node-pool enable-go-pool enable-base-pool \
         setup-cluster install-registry install-observability install-keycloak \
         install-agent-sandbox install-deps install-vibed \
         dev dev-status run-latest teardown clean
@@ -209,6 +213,32 @@ enable-node-pool: load-runner-images
 	@kubectl rollout restart -n vibed-system deploy/vibed-controller
 	@echo "node-24 pool enabled. The validator re-checks on controller restart; first deploy may need ~10s."
 
+enable-go-pool: load-runner-image-go
+	helm upgrade --install vibed deploy/helm/vibed/ \
+		--namespace vibed-system --create-namespace \
+		-f deploy/helm/vibed/values-kind.yaml \
+		--reuse-values \
+		--set warmPools.go-123.enabled=true \
+		--set warmPools.go-123.lane=general \
+		--set warmPools.go-123.image=$(RUNNER_GO_IMAGE) \
+		--set warmPools.go-123.replicas=1 \
+		--wait --timeout 3m
+	@kubectl rollout restart -n vibed-system deploy/vibed-controller
+	@echo "go-123 pool enabled. The validator re-checks on controller restart; first deploy may need ~10s."
+
+enable-base-pool: load-runner-image-base
+	helm upgrade --install vibed deploy/helm/vibed/ \
+		--namespace vibed-system --create-namespace \
+		-f deploy/helm/vibed/values-kind.yaml \
+		--reuse-values \
+		--set warmPools.base-al2023.enabled=true \
+		--set warmPools.base-al2023.lane=general \
+		--set warmPools.base-al2023.image=$(RUNNER_BASE_IMAGE) \
+		--set warmPools.base-al2023.replicas=1 \
+		--wait --timeout 3m
+	@kubectl rollout restart -n vibed-system deploy/vibed-controller
+	@echo "base-al2023 pool enabled. The validator re-checks on controller restart; first deploy may need ~10s."
+
 ## Runner Images (warm-pool runner images for the general/fast lanes)
 ## Build context is the repo root: the Dockerfiles compile the runner agent
 ## from the Go source tree. Built once, not per request.
@@ -220,6 +250,24 @@ runner-image-python:
 
 runner-image-node:
 	podman build -f templates/node-24/Dockerfile -t $(RUNNER_NODE_IMAGE) .
+
+runner-image-go:
+	podman build -f templates/go-123/Dockerfile -t $(RUNNER_GO_IMAGE) .
+
+runner-image-base:
+	podman build -f templates/base-al2023/Dockerfile -t $(RUNNER_BASE_IMAGE) .
+
+# go-123 and base-al2023 load individually (not part of the python+node bundle)
+# so enabling one slot doesn't rebuild the others.
+load-runner-image-go: runner-image-go
+	podman save $(RUNNER_GO_IMAGE) -o /tmp/vibed-runner-go.tar
+	KIND_EXPERIMENTAL_PROVIDER=$(KIND_RUNTIME) kind load image-archive /tmp/vibed-runner-go.tar --name $(KIND_CLUSTER)
+	@rm -f /tmp/vibed-runner-go.tar
+
+load-runner-image-base: runner-image-base
+	podman save $(RUNNER_BASE_IMAGE) -o /tmp/vibed-runner-base.tar
+	KIND_EXPERIMENTAL_PROVIDER=$(KIND_RUNTIME) kind load image-archive /tmp/vibed-runner-base.tar --name $(KIND_CLUSTER)
+	@rm -f /tmp/vibed-runner-base.tar
 
 load-runner-images: runner-images
 	podman save $(RUNNER_PYTHON_IMAGE) -o /tmp/vibed-runner-python.tar

--- a/docs/docs/getting-started/first-deployment.md
+++ b/docs/docs/getting-started/first-deployment.md
@@ -29,6 +29,46 @@ Then ask Claude to deploy something:
 
 Claude calls `deploy_artifact`; vibeD classifies the source, claims a warm sandbox, injects the source, and returns a URL once the app is `Ready`. See the [MCP tools overview](../mcp-tools/overview.md).
 
+## Connect Goose (MCP)
+
+[Goose](https://block.github.io/goose/) speaks MCP natively, so it connects to vibeD's `/mcp` endpoint directly as a **Streamable HTTP** extension — no `mcp-remote` bridge needed.
+
+Interactively:
+
+```bash
+goose configure
+# → Add Extension → Remote Extension (Streamable HTTP)
+#   Name: vibed
+#   URL:  http://localhost:8080/mcp
+```
+
+Or add it to `~/.config/goose/config.yaml` directly:
+
+```yaml
+extensions:
+  vibed:
+    enabled: true
+    type: streamable_http
+    name: vibed
+    uri: http://localhost:8080/mcp
+    timeout: 300
+```
+
+If you've enabled auth on the vibeD API, pass the token as a header (dev installs need none):
+
+```yaml
+    headers:
+      Authorization: "Bearer <your-token>"
+```
+
+Then start a session and ask Goose to deploy — it calls the same `deploy_artifact` tool:
+
+```bash
+goose session
+```
+
+> "Deploy a static site that says hello to vibeD."
+
 ## Deploy via the HTTP API
 
 `POST /v1/deploy` takes a multipart upload: a gzipped source tarball plus a JSON `metadata` blob.

--- a/docs/docs/getting-started/local-dev.md
+++ b/docs/docs/getting-started/local-dev.md
@@ -59,11 +59,13 @@ make enable-python-pool
 
 # Node: same shape, vibed-runner-node:dev + warmPools.node-24.
 make enable-node-pool
+
+# Go and the base image work the same way:
+make enable-go-pool
+make enable-base-pool
 ```
 
-After ~30s the warm pod is `Ready`, the validation ConfigMap shows `valid:true`, and `POST /v1/deploy` with a Python/Node source goes `Phase=Ready` instead of `Failed`.
-
-`go-123` and `base-al2023` work the same way but don't have ready-made Make targets yet — copy the `enable-python-pool` recipe and substitute the slot + image.
+After ~30s the warm pod is `Ready`, the validation ConfigMap shows `valid:true`, and `POST /v1/deploy` with a matching source goes `Phase=Ready` instead of `Failed`.
 
 ## Verify
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   ArtifactSummary,
   WhoAmI,
@@ -73,6 +73,27 @@ function App() {
   const [isAdmin, setIsAdmin] = useState(false)
   const [profile, setProfile] = useState<WhoAmI | null>(null)
   const [showProfile, setShowProfile] = useState(false)
+  const profileRef = useRef<HTMLDivElement>(null)
+
+  // Close the profile menu on outside click or Escape (in addition to the
+  // onMouseLeave below), so it doesn't linger open.
+  useEffect(() => {
+    if (!showProfile) return
+    const onPointerDown = (e: MouseEvent) => {
+      if (profileRef.current && !profileRef.current.contains(e.target as Node)) {
+        setShowProfile(false)
+      }
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowProfile(false)
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [showProfile])
   const [orgName, setOrgName] = useState<string>('')
   const [totalArtifacts, setTotalArtifacts] = useState(0)
   const [needsAuth, setNeedsAuth] = useState(false)
@@ -242,7 +263,7 @@ function App() {
             <span aria-hidden="true">⚙</span>
           </button>
           {currentUser && (
-            <div className="profile-wrapper">
+            <div className="profile-wrapper" ref={profileRef} onMouseLeave={() => setShowProfile(false)}>
               <button className="profile-trigger" onClick={() => setShowProfile(!showProfile)}>
                 <span className="profile-avatar">
                   {(profile?.name || currentUser).charAt(0).toUpperCase()}


### PR DESCRIPTION
Three small fixes from a getting-started dry run.

## Profile/Admin menu doesn't auto-close
It only closed by clicking the trigger again. Now it closes on **outside click**, **Escape**, and **mouse leaving** the menu (`useRef` + document listeners + `onMouseLeave`). `web/src/App.tsx`.

## Missing Make targets for go-123 and base-al2023
node/python/static-nginx had build+load+enable targets; go-123 and base-al2023 didn't (local-dev docs told you to hand-copy a recipe). Added `make enable-go-pool` and `make enable-base-pool`, plus their `runner-image-*` / `load-runner-image-*` helpers — mirroring `enable-python-pool`/`enable-node-pool`. Each loads only its own image so enabling one slot doesn't rebuild the others. Updated the local-dev note.

## "Use vibeD with Goose" docs
Added a **Connect Goose (MCP)** section to First Deployment. Goose speaks MCP natively, so it connects to `/mcp` as a **Streamable HTTP** extension directly (no `mcp-remote` bridge, unlike Claude Desktop) — shown both via `goose configure` and a `~/.config/goose/config.yaml` snippet, with the auth-header option.

## Verified
`tsc && vite build` (web) clean; Docusaurus build clean; `make -n enable-go-pool enable-base-pool` parses.

Addresses dev-experience feedback from a manual dry run (no filed issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)