### PR TITLE
feat(metrics): instrument the /v1 deploy path + MCP tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/internal/deploy/query.go
+++ b/internal/deploy/query.go
@@ -109,6 +109,10 @@ func (s *Service) Delete(ctx context.Context, owner, id string) error {
 	if err := s.record(ctx, "delete", id, "ok", ""); err != nil {
 		return fmt.Errorf("delete succeeded but audit failed: %w", err)
 	}
+	if s.Metrics != nil {
+		// Mirror the Deploy-path Inc so the live-apps gauge stays balanced.
+		s.Metrics.ArtifactsActive.WithLabelValues(app.Spec.Runtime.Template).Dec()
+	}
 	// Usage event, reusing the tenant resolved above.
 	s.meter(ctx, meter.Event{Kind: "delete", Tenant: t.ID, Owner: owner, App: id, Namespace: t.Namespace})
 	return nil

--- a/internal/deploy/service.go
+++ b/internal/deploy/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vibed-project/vibeD/internal/audit"
 	"github.com/vibed-project/vibeD/internal/classifier"
 	"github.com/vibed-project/vibeD/internal/meter"
+	"github.com/vibed-project/vibeD/internal/metrics"
 	"github.com/vibed-project/vibeD/internal/policy"
 	"github.com/vibed-project/vibeD/internal/tarball"
 	"github.com/vibed-project/vibeD/internal/tenant"
@@ -73,6 +74,9 @@ type Service struct {
 	// Meter, when set, records a usage event on each deploy/delete. nil disables
 	// metering.
 	Meter meter.Sink
+	// Metrics, when set, records Prometheus deploy/artifact counters. nil
+	// disables instrumentation (e.g. in tests).
+	Metrics *metrics.Metrics
 }
 
 // Quota gates new deploys within a tenant and resolves the owner's department
@@ -184,6 +188,26 @@ func (s *Service) Deploy(ctx context.Context, req Request) (*Result, error) {
 		return nil, fmt.Errorf("get VibedApp: %w", getErr)
 	}
 
+	// Deploy outcome metric: template + isNew are known now, so a single defer
+	// records success/failure for every return below (a waitReady timeout is
+	// still a successful deploy — the CR was created — hence the explicit flag
+	// rather than keying off the returned error). ArtifactsActive tracks live
+	// apps, so it only rises on a genuinely new app (a redeploy reuses the CR).
+	deployed := false
+	defer func() {
+		if s.Metrics == nil {
+			return
+		}
+		if !deployed {
+			s.Metrics.DeploysTotal.WithLabelValues("failed", template).Inc()
+			return
+		}
+		s.Metrics.DeploysTotal.WithLabelValues("success", template).Inc()
+		if isNew {
+			s.Metrics.ArtifactsActive.WithLabelValues(template).Inc()
+		}
+	}()
+
 	// Policy gate: evaluated on every deploy (new AND redeploy — a redeploy can
 	// introduce a new violation) after classification, before anything is
 	// stored. A denial aborts the deploy.
@@ -277,6 +301,7 @@ func (s *Service) Deploy(ctx context.Context, req Request) (*Result, error) {
 		return nil, fmt.Errorf("deploy succeeded but audit failed: %w", err)
 	}
 	s.meter(ctx, meter.Event{Kind: "deploy", Tenant: t.ID, Owner: req.Owner, App: req.Name, Namespace: t.Namespace})
+	deployed = true
 	return s.waitReady(ctx, t.Namespace, req.Name)
 }
 

--- a/internal/deploy/service_test.go
+++ b/internal/deploy/service_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +23,7 @@ import (
 	"github.com/vibed-project/vibeD/internal/audit"
 	"github.com/vibed-project/vibeD/internal/classifier"
 	"github.com/vibed-project/vibeD/internal/meter"
+	"github.com/vibed-project/vibeD/internal/metrics"
 	"github.com/vibed-project/vibeD/internal/policy"
 	"github.com/vibed-project/vibeD/internal/store"
 	"github.com/vibed-project/vibeD/internal/tarball"
@@ -155,6 +157,40 @@ func TestDeployReachesReady(t *testing.T) {
 	}
 	if store.puts() != 1 {
 		t.Errorf("expected 1 tarball put, got %d", store.puts())
+	}
+}
+
+func TestDeployAndDeleteRecordMetrics(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&vibedv1.VibedApp{}).Build()
+	svc := newService(c, newFakeStore())
+	svc.Metrics = metrics.New()
+	const tmpl = "static-nginx" // index.html classifies to the static fast lane
+
+	deploysBefore := testutil.ToFloat64(svc.Metrics.DeploysTotal.WithLabelValues("success", tmpl))
+	activeBefore := testutil.ToFloat64(svc.Metrics.ArtifactsActive.WithLabelValues(tmpl))
+
+	if _, err := svc.Deploy(context.Background(), Request{
+		Name:    "metricsapp",
+		Owner:   "alice@example.com",
+		Tarball: bytes.NewReader(gzTarball(t, map[string]string{"index.html": "<h1>hi</h1>"})),
+	}); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	if d := testutil.ToFloat64(svc.Metrics.DeploysTotal.WithLabelValues("success", tmpl)) - deploysBefore; d != 1 {
+		t.Fatalf("deploys_total{success,%s} delta = %v, want 1", tmpl, d)
+	}
+	if d := testutil.ToFloat64(svc.Metrics.ArtifactsActive.WithLabelValues(tmpl)) - activeBefore; d != 1 {
+		t.Fatalf("artifacts_active{%s} delta after deploy = %v, want 1", tmpl, d)
+	}
+
+	// Delete balances the live-apps gauge back to where it started.
+	if err := svc.Delete(context.Background(), "alice@example.com", "metricsapp"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if d := testutil.ToFloat64(svc.Metrics.ArtifactsActive.WithLabelValues(tmpl)) - activeBefore; d != 0 {
+		t.Fatalf("artifacts_active{%s} delta after delete = %v, want 0", tmpl, d)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,9 +1,12 @@
 package mcp
 
 import (
+	"context"
+
 	"github.com/vibed-project/vibeD/internal/audit"
 	"github.com/vibed-project/vibeD/internal/config"
 	"github.com/vibed-project/vibeD/internal/deploy"
+	"github.com/vibed-project/vibeD/internal/metrics"
 	"github.com/vibed-project/vibeD/internal/orchestrator"
 	"github.com/vibed-project/vibeD/internal/store"
 
@@ -19,7 +22,34 @@ func NewServer(orch *orchestrator.Orchestrator, deploySvc *deploy.Service, limit
 		Version: "0.1.0",
 	}, nil)
 
+	// Count every tool call (vibed_mcp_tool_calls_total). metrics.New() is a
+	// singleton, so this shares the registry with the rest of the server.
+	server.AddReceivingMiddleware(toolCallMetrics(metrics.New()))
+
 	RegisterTools(server, orch, deploySvc, limits, userStore, auditRec)
 
 	return server
+}
+
+// toolCallMetrics counts every tools/call invocation, labeled by tool name and
+// success/error. Registered as receiving middleware so it covers all tools
+// without touching each handler.
+func toolCallMetrics(m *metrics.Metrics) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			res, err := next(ctx, method, req)
+			if method == "tools/call" {
+				tool := "unknown"
+				if p, ok := req.GetParams().(*mcp.CallToolParams); ok && p.Name != "" {
+					tool = p.Name
+				}
+				status := "success"
+				if err != nil {
+					status = "error"
+				}
+				m.ToolCallsTotal.WithLabelValues(tool, status).Inc()
+			}
+			return res, err
+		}
+	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -597,6 +597,7 @@ func buildDeployService(cfg *config.Config, k8sClients *k8s.Clients, logger *slo
 		Store:      store,
 		Classifier: classifier.Classifier{},
 		Namespace:  appsNS,
+		Metrics:    metrics.New(),
 	}, nil
 }
 


### PR DESCRIPTION
The Grafana overview's **Deploy Success Rate**, **Active Artifacts**, and **MCP Tool Usage** panels were empty — `vibed_deploys_total`, `vibed_artifacts_active`, and `vibed_mcp_tool_calls_total` were only emitted on the legacy orchestrator path, which the VibedApp `/v1` architecture bypasses.

## Changes
- **`deploy.Service`** gains an optional `Metrics` field (nil-safe, matching its `Audit`/`Meter` pattern):
  - `Deploy` records `deploys_total{status,target}` for every outcome via a single deferred counter. A `waitReady` timeout is still a *successful* deploy (the CR was created), so it keys off an explicit flag rather than the returned error.
  - `artifacts_active` rises only for a genuinely **new** app (a redeploy reuses the CR); `Delete` decrements it, keeping the live-apps gauge balanced. Target label = the runtime template.
- **MCP** tool calls are counted via a **receiving middleware** on the server, so `mcp_tool_calls_total{tool,status}` covers every tool without editing each handler.
- Wire `Metrics` into the `deploy.Service` built in `pkg/server` (`metrics.New()` is a singleton, so it shares the registry).

## Test
`TestDeployAndDeleteRecordMetrics`: a deploy then delete moves `deploys_total{success}` +1 and `artifacts_active` +1 then back to 0. `go.mod` gains one indirect dep (`client_golang/prometheus/testutil`).

First slice of the dashboard `/v1` migration (fixes the three empty panels from a manual dry run). Live logs, versions, and share-links follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)