### PR TITLE
feat(logs): wire the dashboard to the live /v1 log stream

### DIFF
--- a/pkg/vibedapi/http/server.go
+++ b/pkg/vibedapi/http/server.go
@@ -436,7 +436,11 @@ func (s *Server) StreamAppLogs(w http.ResponseWriter, r *http.Request, appID App
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	err := s.Deploy.StreamLogs(r.Context(), owner, appID, true, 200, func(line string) error {
+	// Default to a terminating snapshot of the recent tail so a plain GET
+	// completes (the dashboard polls it); `?follow=true` keeps the stream open
+	// for a live tail.
+	follow := r.URL.Query().Get("follow") == "true"
+	err := s.Deploy.StreamLogs(r.Context(), owner, appID, follow, 200, func(line string) error {
 		if _, werr := fmt.Fprintf(w, "data: %s\n\n", line); werr != nil {
 			return werr
 		}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -177,9 +177,17 @@ export async function fetchArtifact(id: string): Promise<Artifact> {
 }
 
 export async function fetchLogs(id: string): Promise<LogsResponse> {
-  // /v1/apps/{id}/logs is not implemented yet (SSE stub). Degrade gracefully
-  // so the log viewer shows a notice instead of throwing.
-  return { artifact_id: id, logs: ['Live logs are not yet available for v0.3.1 apps.'] };
+  // GET /v1/apps/{id}/logs streams the recent tail as Server-Sent Events
+  // (`data: <line>` per event) and, without `?follow=true`, terminates once the
+  // snapshot is sent — so a plain fetch resolves. The viewer polls this.
+  const res = await fetchWithTimeout(`${BASE}/v1/apps/${id}/logs`);
+  if (res.status === 404) return { artifact_id: id, logs: [] };
+  if (!res.ok) throw new Error(`Failed to fetch logs: ${res.statusText}`);
+  const logs = (await res.text())
+    .split('\n')
+    .filter((l) => l.startsWith('data: '))
+    .map((l) => l.slice('data: '.length));
+  return { artifact_id: id, logs };
 }
 
 export async function deleteArtifact(id: string): Promise<void> {


### PR DESCRIPTION
The dashboard's `fetchLogs` was a hardcoded stub ("Live logs are not yet available for v0.3.1 apps") that never called the backend — even though `GET /v1/apps/{id}/logs` is **fully implemented** (SSE over `deploy.Service.StreamLogs`, ownership-checked, with a per-user stream cap). Only the UI was wired to a placeholder.

## Changes
- **Server**: `GET /v1/apps/{id}/logs` now defaults to a **terminating snapshot** of the recent tail, so a plain fetch completes; `?follow=true` keeps the stream open for a live tail. Previously it always followed, which a one-shot client can't consume.
- **UI**: `fetchLogs` now GETs the endpoint and parses the SSE `data:` lines; the log viewer's existing 3s poll surfaces fresh logs. A 404 yields an empty list.

## Verified
`go build ./...` + the `pkg/vibedapi/http` tests pass (incl. `TestStreamLogsSSE`, unaffected by the follow-default change); `tsc && vite build` clean.

Slice 2 of the dashboard `/v1` migration (fixes the stubbed live-logs viewer from a manual dry run). Metrics shipped in #97; versions + share-links follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)