### PR TITLE
feat(share-links): password-optional public links for /v1 apps

### DIFF
--- a/internal/deploy/service.go
+++ b/internal/deploy/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vibed-project/vibeD/internal/meter"
 	"github.com/vibed-project/vibeD/internal/metrics"
 	"github.com/vibed-project/vibeD/internal/policy"
+	"github.com/vibed-project/vibeD/internal/store"
 	"github.com/vibed-project/vibeD/internal/tarball"
 	"github.com/vibed-project/vibeD/internal/tenant"
 	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
@@ -77,6 +78,12 @@ type Service struct {
 	// Metrics, when set, records Prometheus deploy/artifact counters. nil
 	// disables instrumentation (e.g. in tests).
 	Metrics *metrics.Metrics
+
+	// ShareLinks persists public share links. nil disables share links (only the
+	// sqlite store backend implements it). BaseURL is the public origin used to
+	// build a link's shareable URL (e.g. https://apps.example.com).
+	ShareLinks store.ShareLinkStore
+	BaseURL    string
 }
 
 // Quota gates new deploys within a tenant and resolves the owner's department

--- a/internal/deploy/sharelinks.go
+++ b/internal/deploy/sharelinks.go
@@ -1,0 +1,116 @@
+package deploy
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/vibed-project/vibeD/pkg/api"
+	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
+)
+
+// CreateShareLink mints a public, optionally password-protected link to an app
+// the owner owns. The token is the credential; a link resolves to the app's URL.
+func (s *Service) CreateShareLink(ctx context.Context, owner, appID, password string, expiresIn time.Duration) (*api.ShareLink, error) {
+	if s.ShareLinks == nil {
+		return nil, fmt.Errorf("share links require the sqlite store backend")
+	}
+	if _, err := s.Get(ctx, owner, appID); err != nil { // ownership-checked
+		return nil, err
+	}
+
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("generate token: %w", err)
+	}
+	token := hex.EncodeToString(tokenBytes)
+
+	var passwordHash string
+	if password != "" {
+		h, herr := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		if herr != nil {
+			return nil, fmt.Errorf("hash password: %w", herr)
+		}
+		passwordHash = string(h)
+	}
+
+	now := time.Now()
+	link := &api.ShareLink{
+		Token:       token,
+		ArtifactID:  appID,
+		CreatedBy:   owner,
+		HasPassword: password != "",
+		CreatedAt:   now,
+	}
+	if expiresIn > 0 {
+		exp := now.Add(expiresIn)
+		link.ExpiresAt = &exp
+	}
+	if s.BaseURL != "" {
+		link.URL = s.BaseURL + "/share/" + token
+	}
+	if err := s.ShareLinks.CreateShareLink(ctx, link, passwordHash); err != nil {
+		return nil, err
+	}
+	return link, nil
+}
+
+// ListShareLinks returns the app's share links if owner owns it.
+func (s *Service) ListShareLinks(ctx context.Context, owner, appID string) ([]api.ShareLink, error) {
+	if s.ShareLinks == nil {
+		return nil, fmt.Errorf("share links require the sqlite store backend")
+	}
+	if _, err := s.Get(ctx, owner, appID); err != nil {
+		return nil, err
+	}
+	return s.ShareLinks.ListShareLinks(ctx, appID)
+}
+
+// RevokeShareLink revokes a token if owner owns the app it points at.
+func (s *Service) RevokeShareLink(ctx context.Context, owner, token string) error {
+	if s.ShareLinks == nil {
+		return fmt.Errorf("share links require the sqlite store backend")
+	}
+	link, _, err := s.ShareLinks.GetShareLink(ctx, token)
+	if err != nil {
+		return err
+	}
+	if _, err := s.Get(ctx, owner, link.ArtifactID); err != nil {
+		return err
+	}
+	return s.ShareLinks.RevokeShareLink(ctx, token)
+}
+
+// ResolveShareLink validates a public token (and optional password) and returns
+// the target app. Unauthenticated — the token is the credential. Revoked,
+// expired, and unknown tokens all return ErrShareLinkNotFound (no leakage); a
+// missing/wrong password returns ErrPasswordRequired.
+func (s *Service) ResolveShareLink(ctx context.Context, token, password string) (*vibedv1.VibedApp, error) {
+	if s.ShareLinks == nil {
+		return nil, fmt.Errorf("share links require the sqlite store backend")
+	}
+	s.defaults()
+	link, passwordHash, err := s.ShareLinks.GetShareLink(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	if link.Revoked || (link.ExpiresAt != nil && time.Now().After(*link.ExpiresAt)) {
+		return nil, &api.ErrShareLinkNotFound{Token: token}
+	}
+	if passwordHash != "" {
+		if password == "" || bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) != nil {
+			return nil, &api.ErrPasswordRequired{}
+		}
+	}
+
+	app := &vibedv1.VibedApp{}
+	if gerr := s.Client.Get(ctx, types.NamespacedName{Name: link.ArtifactID, Namespace: s.Namespace}, app); gerr != nil {
+		return nil, &api.ErrShareLinkNotFound{Token: token}
+	}
+	return app, nil
+}

--- a/internal/deploy/sharelinks_test.go
+++ b/internal/deploy/sharelinks_test.go
@@ -1,0 +1,119 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vibed-project/vibeD/pkg/api"
+	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// fakeShareLinkStore is an in-memory store.ShareLinkStore for tests.
+type fakeShareLinkStore struct {
+	links map[string]*api.ShareLink
+	hash  map[string]string
+}
+
+func newFakeShareLinkStore() *fakeShareLinkStore {
+	return &fakeShareLinkStore{links: map[string]*api.ShareLink{}, hash: map[string]string{}}
+}
+
+func (f *fakeShareLinkStore) CreateShareLink(_ context.Context, l *api.ShareLink, h string) error {
+	cp := *l
+	f.links[l.Token] = &cp
+	f.hash[l.Token] = h
+	return nil
+}
+
+func (f *fakeShareLinkStore) GetShareLink(_ context.Context, t string) (*api.ShareLink, string, error) {
+	l, ok := f.links[t]
+	if !ok {
+		return nil, "", &api.ErrShareLinkNotFound{Token: t}
+	}
+	return l, f.hash[t], nil
+}
+
+func (f *fakeShareLinkStore) ListShareLinks(_ context.Context, artifactID string) ([]api.ShareLink, error) {
+	var out []api.ShareLink
+	for _, l := range f.links {
+		if l.ArtifactID == artifactID {
+			out = append(out, *l)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeShareLinkStore) RevokeShareLink(_ context.Context, t string) error {
+	if l, ok := f.links[t]; ok {
+		l.Revoked = true
+	}
+	return nil
+}
+
+func TestShareLinks(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&vibedv1.VibedApp{}).Build()
+	svc := newService(c, newFakeStore())
+	svc.DeployTimeout = 50 * time.Millisecond
+	svc.ShareLinks = newFakeShareLinkStore()
+	svc.BaseURL = "https://apps.example.test"
+
+	if _, err := svc.Deploy(context.Background(), Request{
+		Name: "shareapp", Owner: "alice@example.com",
+		Tarball: bytes.NewReader(gzTarball(t, map[string]string{"index.html": "<h1>hi</h1>"})),
+	}); err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	// Give the app a URL so resolve returns it.
+	app := &vibedv1.VibedApp{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "shareapp", Namespace: "vibed-apps"}, app); err != nil {
+		t.Fatal(err)
+	}
+	app.Status.URL = "https://abc.apps.example.test"
+	if err := c.Status().Update(context.Background(), app); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := svc.CreateShareLink(context.Background(), "alice@example.com", "shareapp", "secret", time.Hour)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(link.Token) != 64 || !link.HasPassword || link.URL == "" {
+		t.Fatalf("unexpected link: %+v", link)
+	}
+
+	// A non-owner cannot create a link (ownership-checked, no existence leak).
+	if _, err := svc.CreateShareLink(context.Background(), "bob@example.com", "shareapp", "", 0); err == nil {
+		t.Fatal("expected error for non-owner create")
+	}
+
+	links, err := svc.ListShareLinks(context.Background(), "alice@example.com", "shareapp")
+	if err != nil || len(links) != 1 {
+		t.Fatalf("list: err=%v n=%d", err, len(links))
+	}
+
+	// Resolve requires the password, then returns the app.
+	if _, err := svc.ResolveShareLink(context.Background(), link.Token, ""); err == nil {
+		t.Fatal("expected password-required error")
+	}
+	got, err := svc.ResolveShareLink(context.Background(), link.Token, "secret")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Status.URL != "https://abc.apps.example.test" {
+		t.Fatalf("resolve URL = %q", got.Status.URL)
+	}
+
+	// Revoked links no longer resolve.
+	if err := svc.RevokeShareLink(context.Background(), "alice@example.com", link.Token); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := svc.ResolveShareLink(context.Background(), link.Token, "secret"); err == nil {
+		t.Fatal("expected not-found after revoke")
+	}
+}

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -6,6 +6,7 @@ import (
         "crypto/sha256"
         "encoding/hex"
         "encoding/json"
+        "errors"
         "fmt"
         "io"
         "io/fs"
@@ -19,6 +20,7 @@ import (
 
         vibedauth "github.com/vibed-project/vibeD/internal/auth"
         "github.com/vibed-project/vibeD/internal/config"
+	"github.com/vibed-project/vibeD/internal/deploy"
 	"github.com/vibed-project/vibeD/internal/events"
 	"github.com/vibed-project/vibeD/internal/k8s"
 	"github.com/vibed-project/vibeD/internal/metrics"
@@ -47,7 +49,7 @@ func writeError(w http.ResponseWriter, err error, fallbackStatus int) {
 }
 
 // NewHandler creates an HTTP handler that serves the frontend and REST API.
-func NewHandler(orch *orchestrator.Orchestrator, cfg *config.Config, bus *events.EventBus, m *metrics.Metrics, userStore store.UserStore, k8sClients *k8s.Clients) http.Handler {
+func NewHandler(orch *orchestrator.Orchestrator, deploySvc *deploy.Service, cfg *config.Config, bus *events.EventBus, m *metrics.Metrics, userStore store.UserStore, k8sClients *k8s.Clients) http.Handler {
         mux := http.NewServeMux()
 
         // API documentation (Swagger UI)
@@ -58,8 +60,8 @@ func NewHandler(orch *orchestrator.Orchestrator, cfg *config.Config, bus *events
         mux.HandleFunc("/api/events", handleSSE(bus, m))
 
         // API routes
-        mux.HandleFunc("/api/artifacts", handleArtifacts(orch))
-        mux.HandleFunc("/api/artifacts/", handleArtifacts(orch))
+        mux.HandleFunc("/api/artifacts", handleArtifacts(orch, deploySvc))
+        mux.HandleFunc("/api/artifacts/", handleArtifacts(orch, deploySvc))
         mux.HandleFunc("/api/targets", handleTargets(orch))
         mux.HandleFunc("/api/whoami", handleWhoami(userStore))
         mux.HandleFunc("/api/organization", handleOrganization(cfg))
@@ -68,8 +70,8 @@ func NewHandler(orch *orchestrator.Orchestrator, cfg *config.Config, bus *events
         mux.HandleFunc("/api/departments", handleDepartments(userStore, k8sClients))
         mux.HandleFunc("/api/departments/", handleDepartmentDetail(userStore, k8sClients))
 	// Share link routes (public — auth bypassed in SkipAuthPaths)
-	mux.HandleFunc("/api/share/", handlePublicShareLink(orch))
-	mux.HandleFunc("/api/share-links/", handleShareLinkRevoke(orch))
+	mux.HandleFunc("/api/share/", handlePublicShareLink(orch, deploySvc))
+	mux.HandleFunc("/api/share-links/", handleShareLinkRevoke(orch, deploySvc))
 
 	// Browser-friendly share link page — serves the SPA so React renders ShareLinkPage.
 	// The React app detects /share/<token> and calls /api/share/<token> as JSON.
@@ -91,7 +93,7 @@ func NewHandler(orch *orchestrator.Orchestrator, cfg *config.Config, bus *events
 	return limitRequestBody(mux, cfg.Limits.MaxTotalFileSize)
 }
 
-func handleArtifacts(orch *orchestrator.Orchestrator) http.HandlerFunc {
+func handleArtifacts(orch *orchestrator.Orchestrator, deploySvc *deploy.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Handle /api/artifacts/{id} paths
 		path := strings.TrimPrefix(r.URL.Path, "/api/artifacts")
@@ -119,10 +121,10 @@ func handleArtifacts(orch *orchestrator.Orchestrator) http.HandlerFunc {
 					handleArtifactUnshare(orch, artifactID, w, r)
 					return
 				case "share-link":
-					handleArtifactShareLink(orch, artifactID, w, r)
+					handleArtifactShareLink(orch, deploySvc, artifactID, w, r)
 					return
 				case "share-links":
-					handleArtifactShareLinks(orch, artifactID, w, r)
+					handleArtifactShareLinks(orch, deploySvc, artifactID, w, r)
 					return
 				}
 			}
@@ -710,7 +712,7 @@ func handleSPAIndex() http.HandlerFunc {
 }
 
 // POST /api/artifacts/{id}/share-link — create a share link
-func handleArtifactShareLink(orch *orchestrator.Orchestrator, artifactID string, w http.ResponseWriter, r *http.Request) {
+func handleArtifactShareLink(orch *orchestrator.Orchestrator, deploySvc *deploy.Service, artifactID string, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -746,6 +748,23 @@ func handleArtifactShareLink(orch *orchestrator.Orchestrator, artifactID string,
 		}
 	}
 
+	// VibedApp path: create a link for the app the caller owns. Fall back to the
+	// legacy artifact path only when the id isn't a VibedApp.
+	owner := vibedauth.UserIDFromContext(r.Context())
+	if deploySvc != nil && deploySvc.ShareLinks != nil && owner != "" {
+		link, derr := deploySvc.CreateShareLink(r.Context(), owner, artifactID, body.Password, expiresIn)
+		if derr == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if !errors.Is(derr, deploy.ErrNotFound) {
+			writeError(w, derr, http.StatusBadRequest)
+			return
+		}
+	}
+
 	link, err := orch.CreateShareLink(r.Context(), artifactID, body.Password, expiresIn)
 	if err != nil {
 		writeError(w, err, http.StatusBadRequest)
@@ -758,10 +777,27 @@ func handleArtifactShareLink(orch *orchestrator.Orchestrator, artifactID string,
 }
 
 // GET /api/artifacts/{id}/share-links — list share links
-func handleArtifactShareLinks(orch *orchestrator.Orchestrator, artifactID string, w http.ResponseWriter, r *http.Request) {
+func handleArtifactShareLinks(orch *orchestrator.Orchestrator, deploySvc *deploy.Service, artifactID string, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
+	}
+
+	owner := vibedauth.UserIDFromContext(r.Context())
+	if deploySvc != nil && deploySvc.ShareLinks != nil && owner != "" {
+		links, derr := deploySvc.ListShareLinks(r.Context(), owner, artifactID)
+		if derr == nil {
+			if links == nil {
+				links = []api.ShareLink{}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(links)
+			return
+		}
+		if !errors.Is(derr, deploy.ErrNotFound) {
+			writeError(w, derr, http.StatusBadRequest)
+			return
+		}
 	}
 
 	links, err := orch.ListShareLinks(r.Context(), artifactID)
@@ -778,7 +814,7 @@ func handleArtifactShareLinks(orch *orchestrator.Orchestrator, artifactID string
 }
 
 // DELETE /api/share-links/{token} — revoke a share link
-func handleShareLinkRevoke(orch *orchestrator.Orchestrator) http.HandlerFunc {
+func handleShareLinkRevoke(orch *orchestrator.Orchestrator, deploySvc *deploy.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -788,6 +824,20 @@ func handleShareLinkRevoke(orch *orchestrator.Orchestrator) http.HandlerFunc {
 		if token == "" {
 			http.Error(w, "missing token", http.StatusBadRequest)
 			return
+		}
+
+		owner := vibedauth.UserIDFromContext(r.Context())
+		if deploySvc != nil && deploySvc.ShareLinks != nil && owner != "" {
+			derr := deploySvc.RevokeShareLink(r.Context(), owner, token)
+			if derr == nil {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
+				return
+			}
+			if !errors.Is(derr, deploy.ErrNotFound) {
+				writeError(w, derr, http.StatusNotFound)
+				return
+			}
 		}
 
 		if err := orch.RevokeShareLink(r.Context(), token); err != nil {
@@ -800,7 +850,7 @@ func handleShareLinkRevoke(orch *orchestrator.Orchestrator) http.HandlerFunc {
 }
 
 // GET/POST /api/share/{token} — public share link resolution
-func handlePublicShareLink(orch *orchestrator.Orchestrator) http.HandlerFunc {
+func handlePublicShareLink(orch *orchestrator.Orchestrator, deploySvc *deploy.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.URL.Path, "/api/share/")
 		if token == "" {
@@ -815,6 +865,28 @@ func handlePublicShareLink(orch *orchestrator.Orchestrator) http.HandlerFunc {
 			}
 			json.NewDecoder(r.Body).Decode(&body)
 			password = body.Password
+		}
+
+		// VibedApp path: resolve the token to the app's URL. A wrong/missing
+		// password is a 401; anything else falls through to the legacy artifact
+		// resolve (the store is shared, so an artifact link is found there).
+		if deploySvc != nil && deploySvc.ShareLinks != nil {
+			app, derr := deploySvc.ResolveShareLink(r.Context(), token, password)
+			if derr == nil {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"name":   app.Name,
+					"status": string(app.Status.Phase),
+					"url":    app.Status.URL,
+					"target": "app",
+				})
+				return
+			}
+			var pwReq *api.ErrPasswordRequired
+			if errors.As(derr, &pwReq) {
+				writeError(w, derr, http.StatusUnauthorized)
+				return
+			}
 		}
 
 		artifact, err := orch.ResolveShareLink(r.Context(), token, password)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -308,6 +308,8 @@ func Run(cfg *config.Config, logger *slog.Logger) {
 	}
 	if deploySvc != nil {
 		deploySvc.Audit = auditRec
+		deploySvc.ShareLinks = shareLinkStore // nil unless the sqlite backend is in use
+		deploySvc.BaseURL = cfg.Server.BaseURL
 		if cfg.Quotas.Enabled {
 			ns := deploySvc.Namespace
 			if ns == "" {
@@ -462,7 +464,7 @@ func runHTTPServer(ctx context.Context, cfg *config.Config, mcpServer *mcp.Serve
 	// app, so there's no longer a per-process proxy living here.)
 
 	// Frontend + API
-	frontendHandler := frontend.NewHandler(orch, cfg, bus, m, userStore, k8sClients)
+	frontendHandler := frontend.NewHandler(orch, deploySvc, cfg, bus, m, userStore, k8sClients)
 	mux.Handle("/", frontendHandler)
 
 	// Build handler chain: role → auth (selective) → metrics → mux


### PR DESCRIPTION
"Create share link" failed with **404** for VibedApps — the handlers validated the id against the legacy *artifact* store, which doesn't hold VibedApps. The `ShareLinkStore` itself is generic (keyed by any id string), so it already fits `app_id`; only validation/resolution were artifact-specific.

## Backend
- `deploy.Service` gains an optional `ShareLinks` store + `BaseURL` and app-aware methods:
  - **CreateShareLink** — ownership-checked, 64-hex token, bcrypt password (reuses the existing scheme).
  - **ListShareLinks** / **RevokeShareLink** (must own the linked app).
  - **ResolveShareLink** — unauthenticated (the token is the credential); returns the app so the public page shows/redirects to its URL. Revoked/expired/unknown tokens → not-found (no leakage); missing/wrong password → 401.
- Wired the share-link store (**sqlite backend only**) + `BaseURL` into the deploy service in `pkg/server`.

## Frontend
- The four share-link routes (`/api/artifacts/{id}/share-link[s]`, `/api/share-links/{token}`, `/api/share/{token}`) now **try the app path first** and fall back to the legacy artifact path only when the id/token isn't a VibedApp — so existing artifact links keep working. **No UI change** — the routes are unchanged; they just resolve VibedApps now.

## Test
`TestShareLinks`: create (owner-gated; non-owner rejected) → list → password-gated resolve to the app URL → revoke → resolve fails. `go build ./...` + `go vet` + the `internal/deploy` tests pass.

Final slice of the dashboard `/v1` migration (metrics #97, logs #98, versions #99). Fixes "Failed to create share link: Not Found" from a dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)