### PR TITLE
release: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to vibeD are recorded here. The format loosely follows
+[Keep a Changelog](https://keepachangelog.com/); each release is also a signed
+git tag, and the Helm chart's `appVersion` tracks the release.
+
+## v0.5.0 — 2026-07-09
+
+The `/v1` app data plane reaches parity with the dashboard — version history &
+rollback, live logs, deploy/MCP metrics, and public share links — alongside
+source-fetch hardening and an install-docs overhaul.
+
+### Added
+- **Version history & rollback** for `/v1` apps: every deploy snapshots its
+  source under a monotonic version; `GET /v1/apps/{id}/versions` lists the
+  history and `POST /v1/apps/{id}/rollback` redeploys a prior version (retained
+  up to a fixed cap). (#99)
+- **Live log streaming** on `/v1`: `GET /v1/apps/{id}/logs` returns a snapshot
+  by default and streams with `?follow=true`; the dashboard tails it. (#98)
+- **Deploy & MCP metrics**: Prometheus `deploys_total`, `artifacts_active`, and
+  `tool_calls_total`, powering the dashboard's Deploy Success Rate, Active
+  Artifacts, and MCP Tool Usage panels. (#97)
+- **Public share links** for `/v1` apps: password-optional, revocable links that
+  resolve to an app's URL. (#100)
+- **Warm-pool make targets** `enable-go-pool` and `enable-base-pool` for the
+  `go-123` / `base-al2023` templates. (#96)
+
+### Security
+- **Source-fetch hardening** in the runner agent: an SSRF dial guard (blocks
+  link-local / loopback / cloud-metadata addresses, including the IPv6 IMDS) and
+  decompression-bomb caps that count bytes *written* against a shared budget, so
+  PAX sparse-file entries can't slip past. (#94)
+
+### Changed
+- Helm chart gains a `warmPoolsEnabled` master switch so a first `helm install`
+  succeeds before the agent-sandbox **extensions** CRDs are present — set it
+  `false`, then flip it on `helm upgrade`. Chart `version`/`appVersion` → 0.5.0.
+  (#95)
+- The dashboard profile menu now auto-closes on mouse-leave. (#96)
+
+### Docs
+- Installation guide split into a dev path (`make dev`, no S3) and a production
+  path, with agent-sandbox core-vs-extensions + version guidance and the
+  CRD-ordering fix; **Local Development** moved first in the nav. (#95)
+- Goose MCP extension setup; a **manual test runbook** (runtimes × configs); and
+  the `/v1` versions/rollback endpoints plus log `?follow` documented in the
+  HTTP API reference. (#96, #101)
+
+### Upgrading
+- **Backward-compatible.** The public Go surface (`pkg/api`, `pkg/plugin`,
+  `pkg/server`) is unchanged and the new `/v1` endpoints are additive — no code
+  or config migration. A `helm upgrade` picks up the 0.5.0 images.
+- Installing onto a cluster **without** the agent-sandbox extensions CRDs? Use
+  `--set warmPoolsEnabled=false`, then enable pools once the CRDs are present.
+
+## v0.4.5 — 2026-07-07
+- Config validator now consults the plugin registry (#92): out-of-tree store
+  backends / auth modes registered via `pkg/plugin` validate correctly,
+  completing the plugin extension surface.
+- Documentation website refresh (#93).
+
+## v0.4.4 — 2026-07-06 (security release)
+- Egress SSRF / DNS-rebind hardening (metadata endpoint blocked by resolved IP;
+  IPv6 NetworkPolicy ranges); static-API-key suspension enforcement via a
+  canonical user ID; fail-closed artifact ownership when auth is enabled; plus a
+  batch of smaller security and performance fixes.
+  (#46, #57, #60, #59, #48, #63, #49, #54, #58, #53, #65, #64, #68, #69, #67, #78)
+- **Note:** #48 changes the static-key ownership identity to `apikey-<name>` —
+  see `docs/configuration/authentication.md` before upgrading.
+
+_Earlier releases (v0.4.3 and before) are recorded in their git tags._

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ storage:
     backend: "served"          # served (DEV only) | s3 (PRODUCTION)
 
 store:
-  backend: "sqlite"            # sqlite | configmap
+  backend: "sqlite"            # sqlite | configmap | memory
 ```
 
 Most fields have an environment override (e.g. `VIBED_SERVER_TRANSPORT`). Cluster topology — namespaces, the Kata RuntimeClass, NetworkPolicy, controller/router/Caddy, and the warm pools — is set through Helm values. See the [Configuration Reference](docs/docs/configuration/config-reference.md) for the full list.

--- a/deploy/helm/vibed/Chart.yaml
+++ b/deploy/helm/vibed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vibed
 description: Workload orchestrator for GenAI-generated artifacts
 type: application
-version: 0.4.4
-appVersion: "0.4.4"
+version: 0.5.0
+appVersion: "0.5.0"
 keywords:
   - mcp
   - genai

--- a/docs/docs/reference/http-api.md
+++ b/docs/docs/reference/http-api.md
@@ -159,11 +159,16 @@ Responses: `204` (deleted, empty body), `401`, `404`.
 
 ### `GET /v1/apps/{id}/logs`
 
-Stream logs from the app's runner as a **Server-Sent Events** (SSE) stream. Ownership is checked up front, so a `404` is returned cleanly before the connection is upgraded.
+Read logs from the app's runner as a **Server-Sent Events** (SSE) stream. Ownership is checked up front, so a `404` is returned cleanly before the connection is upgraded. By default the endpoint returns a **snapshot** of recent lines and then closes; pass **`?follow=true`** to keep the connection open and stream new lines as they arrive.
 
 ```bash
+# snapshot (returns, then closes)
 curl -N -H "Authorization: Bearer $VIBED_TOKEN" \
   http://localhost:8080/v1/apps/my-tool/logs
+
+# live tail
+curl -N -H "Authorization: Bearer $VIBED_TOKEN" \
+  "http://localhost:8080/v1/apps/my-tool/logs?follow=true"
 ```
 
 The response is `text/event-stream`; each log line arrives as one event:
@@ -175,6 +180,39 @@ data: 2026-07-03T10:12:02Z listening
 ```
 
 If the stream fails mid-flight, a terminal `event: error` frame is emitted. A client disconnect (cancelled request) is not an error. Concurrent streams per user are capped by [`limits.maxConcurrentLogStreamsPerUser`](../configuration/config-reference.md); exceeding it returns `429` with a `Retry-After` header. Responses: `200` (stream), `401`, `404`, `429`.
+
+### `GET /v1/apps/{id}/versions`
+
+List an app's deploy history, newest first (the first item is the current deployment). Each successful deploy snapshots the source under a monotonic version number, so any listed version can be restored via [rollback](#post-v1appsidrollback). Ownership is checked; a caller that doesn't own the app gets `404`.
+
+```bash
+curl -H "Authorization: Bearer $VIBED_TOKEN" \
+  http://localhost:8080/v1/apps/my-tool/versions
+```
+
+```json
+{
+  "items": [
+    { "version": 3, "timestamp": "2026-07-08T09:41:00Z", "template": "node-24", "lane": "general", "rolled_back_from": 1 },
+    { "version": 2, "timestamp": "2026-07-07T18:02:00Z", "template": "node-24", "lane": "general" },
+    { "version": 1, "timestamp": "2026-07-07T11:20:00Z", "template": "node-24", "lane": "general" }
+  ]
+}
+```
+
+Each entry also carries a `source_hash`; `rolled_back_from` is present only on a version a rollback created (above, v3 restored v1's source). History is retained up to a fixed cap (older versions are pruned as new ones land). Responses: `200`, `401`, `404`.
+
+### `POST /v1/apps/{id}/rollback`
+
+Redeploy an app from a previous version's snapshotted source. The rollback itself becomes a new version at the head of the history (it does not rewrite it). Ownership is checked.
+
+```bash
+curl -X POST -H "Authorization: Bearer $VIBED_TOKEN" \
+  -H "Content-Type: application/json" -d '{"version": 1}' \
+  http://localhost:8080/v1/apps/my-tool/rollback
+```
+
+Returns the same `App` shape as a deploy: `200` when the app is `Ready` within the latency budget, `202` with a `status_url` to poll otherwise. Responses: `200`, `202`, `400` (unknown version), `401`, `404`.
 
 ## Governance
 


### PR DESCRIPTION
Release preparation for **v0.5.0** — the first minor since v0.4.5. **No code changes**; this is the chart bump, CHANGELOG, and release-doc updates.

## Why v0.5.0
Since v0.4.5, main has accumulated a cohesive feature set: `/v1` version history + rollback (#99), live log streaming (#98), deploy/MCP metrics (#97), public share links (#100), source-fetch hardening (#94), and an install-docs overhaul (#95). New `/v1` endpoints ⇒ a minor bump.

## Public-surface audit (drop-in for downstreams that pin the core)
Diffed the exported surface `v0.4.5..HEAD`:
- **`pkg/api`, `pkg/plugin`, and the store interfaces (`ArtifactStore`/`UserStore`/`AuditStore`/`ShareLinkStore`) are unchanged.**
- **`server.Main` is unchanged.**
- The only new public surface is **additive**: the `GetAppVersions` / `RollbackApp` `/v1` handlers on the generated OpenAPI server.

So v0.5.0 is backward-compatible — no code or config migration.

## Changes here
- **`CHANGELOG.md`** (new) — v0.5.0 entry, plus v0.4.5 / v0.4.4 backfilled from their tags.
- **`Chart.yaml`** — `version` + `appVersion` → `0.5.0` (reconciles the 0.4.4 chart vs the v0.4.5 tag drift).
- **`docs/reference/http-api.md`** — documents `GET /v1/apps/{id}/versions`, `POST /v1/apps/{id}/rollback`, and the log `?follow` snapshot-vs-stream default (verified against `api/openapi.yaml`).
- **`README.md`** — adds the `memory` metadata-store backend to the config example.

Verified: `docusaurus build` (onBrokenLinks: throw) passes.

## Merge order / not-yet-done
1. Merge **#100** (share links) and **#101** (runbook) first — the CHANGELOG lists both under v0.5.0.
2. Then merge this.
3. **Tagging + publishing `v0.5.0` is intentionally left to a maintainer** (the release workflow fires on the tag). Adjust the CHANGELOG date if the cut slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)