### PR TITLE
docs: bump website version references to v0.5.0

### DIFF
--- a/docs/docs/configuration/custom-base-images.md
+++ b/docs/docs/configuration/custom-base-images.md
@@ -24,7 +24,7 @@ Your image must satisfy the contract below. The simplest path is to start `FROM`
 
 ```dockerfile
 # Stage 1: grab a statically-linked vibed-agent (or COPY one you've vendored).
-FROM ghcr.io/vibed-project/vibed-runner-node:0.4.4 AS agent
+FROM ghcr.io/vibed-project/vibed-runner-node:0.5.0 AS agent
 
 # Stage 2: your hardened base.
 FROM your-registry/hardened-node:24

--- a/docs/docs/deployment/production-guide.md
+++ b/docs/docs/deployment/production-guide.md
@@ -22,9 +22,9 @@ CI builds and pushes all component images to GHCR: `vibed`, `vibed-controller`, 
 ## 2. Production values
 
 ```yaml
-image: { repository: ghcr.io/vibed-project/vibed, tag: "v0.4.4", pullPolicy: IfNotPresent }
-controller: { image: { tag: "v0.4.4" }, domain: apps.example.com }
-router:     { image: { tag: "v0.4.4" } }
+image: { repository: ghcr.io/vibed-project/vibed, tag: "v0.5.0", pullPolicy: IfNotPresent }
+controller: { image: { tag: "v0.5.0" }, domain: apps.example.com }
+router:     { image: { tag: "v0.5.0" } }
 
 # Sandbox isolation
 runtime:

--- a/docs/docs/mcp-tools/list-versions.md
+++ b/docs/docs/mcp-tools/list-versions.md
@@ -30,14 +30,14 @@ List all version snapshots for a deployed artifact, ordered by version number. E
       "version": 1,
       "status": "running",
       "url": "http://my-portfolio.default.localhost:31080",
-      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.4",
+      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.5.0",
       "created_at": "2026-03-14T10:00:00Z"
     },
     {
       "version": 2,
       "status": "running",
       "url": "http://my-portfolio.default.localhost:31080",
-      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.4.4",
+      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.5.0",
       "created_at": "2026-03-14T12:30:00Z"
     }
   ]

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
           {
             // Current release, shown left of the GitHub link. Bump on release.
             href: 'https://github.com/vibed-project/vibeD/releases',
-            label: 'v0.4.4',
+            label: 'v0.5.0',
             position: 'right',
           },
           {


### PR DESCRIPTION
The docs site still advertised **v0.4.4** after the v0.5.0 release — most visibly the navbar release label.

- **`docusaurus.config.js`** — navbar release label `v0.4.4` → `v0.5.0` (the "still links to the old version" fix).
- **`deployment/production-guide.md`** — pinned `vibed`/`controller`/`router` image tags → `v0.5.0`.
- **`configuration/custom-base-images.md`** + **`mcp-tools/list-versions.md`** — example image refs → `0.5.0`.

Left alone (correct as-is): the historical "Upgrading to v0.4.4" note in `authentication.md` (documents the v0.4.4 ownership change) and the `agent-sandbox v0.4.5+` prerequisites (upstream project version).

Verified with `docusaurus build`.

> Note: the navbar label is a manual per-release bump (the config comment already says "Bump on release"). Happy to fold it into the release workflow or make it point at `/releases/latest` if you'd prefer it not go stale again — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)