### PR TITLE
chart: schedule sandbox pods onto a dedicated pool (nodeSelector + tolerations)

### DIFF
--- a/deploy/helm/vibed/templates/runtimeclass.yaml
+++ b/deploy/helm/vibed/templates/runtimeclass.yaml
@@ -15,9 +15,17 @@ metadata:
   labels:
     {{- include "vibed.labels" . | nindent 4 }}
 handler: {{ .Values.runtime.handler | default .Values.runtime.defaultClass }}
-{{- with .Values.runtime.nodeSelector }}
+{{- if or .Values.runtime.nodeSelector .Values.runtime.tolerations }}
+# Kubernetes merges these into every pod using this RuntimeClass, so Kata
+# sandboxes land on (and tolerate the taint of) the dedicated sandbox pool.
 scheduling:
+  {{- with .Values.runtime.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.runtime.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/vibed/templates/warmpools.yaml
+++ b/deploy/helm/vibed/templates/warmpools.yaml
@@ -35,6 +35,19 @@ spec:
       labels:
         vibed.dev/template: {{ $name }}
     spec:
+      {{- with $root.Values.runtime.nodeSelector }}
+      # Pin these sandbox pods (untrusted, AI-generated code) to a dedicated
+      # node pool. Applied on the pod itself so it holds for BOTH lanes,
+      # regardless of whether the RuntimeClass is Helm-owned.
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $root.Values.runtime.tolerations }}
+      # Tolerate that pool's taint so sandboxes schedule there while everything
+      # else (control plane, system add-ons without this toleration) stays off.
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $root.Values.runtime.defaultClass }}
       # Kata isolation for the general lane. Omitted (normal runtime) when
       # runtime.defaultClass is empty — e.g. on a Kind dev cluster without Kata.

--- a/deploy/helm/vibed/values.yaml
+++ b/deploy/helm/vibed/values.yaml
@@ -83,7 +83,12 @@ runtime:
   defaultClass: kata-qemu      # kata-qemu (dev, no nested virt) | kata-fc (KVM)
   installRuntimeClass: false
   handler: ""                  # defaults to defaultClass
-  nodeSelector: {}             # e.g. { vibed.dev/sandbox-node: "true" }
+  # Schedule warm-pool / sandbox pods (untrusted AI-generated code) onto a
+  # dedicated node pool, away from the control plane. nodeSelector pins them
+  # there; tolerations let them onto a pool you've tainted to keep other
+  # workloads off. Both are applied to the sandbox pod spec (any lane).
+  nodeSelector: {}             # e.g. { k8s.scaleway.com/pool-name: sandbox }
+  tolerations: []              # e.g. [{ key: vibed.dev/sandbox, operator: Exists, effect: NoSchedule }]
   # agent-sandbox NetworkPolicy mode for warm-pool sandboxes:
   #   Managed   — agent-sandbox owns the policy: ingress only from an
   #               `app: sandbox-router` pod (which it doesn't ship) and NO


### PR DESCRIPTION
`runtime.nodeSelector` was declared in `values.yaml` but only wired into the **RuntimeClass** `scheduling` — which affects the general (Kata) lane and only when Helm owns the RuntimeClass. It never constrained the actual warm-pool/sandbox pods, and there was no way to **tolerate a taint** on a dedicated sandbox node pool. So untrusted, AI-generated code could co-schedule with the control plane.

## Change
- **`warmpools.yaml`** — apply `runtime.nodeSelector` + a new `runtime.tolerations` directly to the `SandboxTemplate` `podTemplate.spec`, so sandbox pods land on (and tolerate the taint of) the sandbox pool for **both lanes**, independent of RuntimeClass ownership.
- **`runtimeclass.yaml`** — add `scheduling.tolerations` alongside the existing `nodeSelector` (emit `scheduling` when either is set).
- **`values.yaml`** — add `runtime.tolerations` (default `[]`), document the nodeSelector/tolerations pairing.

## Verify
```
helm template … --set-json runtime.tolerations='[{"key":"vibed.dev/sandbox","operator":"Exists","effect":"NoSchedule"}]' \
  --set runtime.nodeSelector.'k8s\.scaleway\.com/pool-name'=sandbox --show-only templates/warmpools.yaml
```
→ the SandboxTemplate podTemplate gets both `nodeSelector` and `tolerations`; RuntimeClass likewise. `helm lint` passes.

**Additive / backward-compatible** — empty defaults render no scheduling constraints (current behavior). This is the chart half of the vibed-cloud Scaleway sandbox-pool isolation (the taint lives there, since the Scaleway provider has no pool-taint attribute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)