### PR TITLE
chore(docs): clear docs npm moderate advisories (Docusaurus 3.10.2 + uuid override)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,15 +8,15 @@
       "name": "vibed-docs",
       "version": "0.1.0",
       "dependencies": {
-        "@docusaurus/core": "^3.9.0",
-        "@docusaurus/preset-classic": "^3.9.0",
+        "@docusaurus/core": "^3.10.2",
+        "@docusaurus/preset-classic": "^3.10.2",
         "@mdx-js/react": "^3.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.9.0"
+        "@docusaurus/module-type-aliases": "^3.10.2"
       }
     },
     "node_modules/@11ty/gray-matter": {
@@ -17698,12 +17698,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,17 +10,18 @@
     "clear": "docusaurus clear"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.0",
-    "@docusaurus/preset-classic": "^3.9.0",
+    "@docusaurus/core": "^3.10.2",
+    "@docusaurus/preset-classic": "^3.10.2",
     "@mdx-js/react": "^3.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.9.0"
+    "@docusaurus/module-type-aliases": "^3.10.2"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.5"
+    "serialize-javascript": ">=7.0.5",
+    "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
Stacked on #110 (targets `release/v0.5.1`). Clears the last non-dismissed medium/low tail in the Security tab: the 18 moderate npm advisories in `docs/`.

## Root cause
All 18 chained down to **one leaf**: `uuid@8.3.2`, bundled by `sockjs → webpack-dev-server` — Docusaurus's local dev server. Every `@docusaurus/*` alert was flagged only for *depending on* it. `webpack-dev-server@5.2.6` and `sockjs@0.3.24` are already the latest available, so no Docusaurus version drops the chain.

Note: there is no Docusaurus 4 — `latest` is 3.10.2 (we were on 3.9.0). Bumping to 3.10.2 alone changed nothing in the audit; the fix is forcing `uuid` to its patched line via an npm `overrides` entry (`>=11.1.1`, resolves to 14.0.1).

## Changes
- `@docusaurus/*` `^3.9.0` → `^3.10.2` (latest 3.x)
- `overrides.uuid: ">=11.1.1"` in `docs/package.json`

## Verification
- `npm ci` (the `deploy.yml` path) reproduces with **0 vulnerabilities** (was 18 moderate)
- `npm run build` succeeds — this is what GitHub Pages deploys
- `docusaurus start` boots and serves HTTP 200 — this is where `sockjs`/`uuid` actually execute, so it confirms uuid 14.x doesn't break the dev server

## Impact on the Security tab
After #110 + this merge to `main`: Dependabot **0 critical / 0 high / 0 medium / 0 low** on `docs`, and `web` is already clean. Combined with the dismissed Go items (docker/docker client-only) and the code-scanning fixes, the tab reaches zero open findings.

## Test plan
- [x] `npm ci` → 0 vulnerabilities
- [x] `npm run build` succeeds
- [x] `docusaurus start` serves 200