### PR TITLE
Sev sweep (low + medium + high): quota, rate-limits, controller, GC, ConfigMap store, deploy path

### DIFF
--- a/deploy/helm/vibed/templates/configmap.yaml
+++ b/deploy/helm/vibed/templates/configmap.yaml
@@ -43,6 +43,15 @@ data:
         certFile: "/etc/vibed/tls/tls.crt"
         keyFile: "/etc/vibed/tls/tls.key"
       {{- end }}
+    {{- else }}
+    auth:
+      # Auth is disabled: every request is treated as admin. The server binds a
+      # non-loopback address (:8080) in-cluster, so it refuses to start in this
+      # mode unless devInsecure explicitly acknowledges it. The listener is
+      # expected to be fronted by NetworkPolicy — set auth.enabled=true for any
+      # shared or production cluster.
+      enabled: false
+      devInsecure: true
     {{- end }}
     deployment:
       preferredTarget: {{ .Values.config.deployment.preferredTarget | quote }}

--- a/internal/auth/suspend_test.go
+++ b/internal/auth/suspend_test.go
@@ -38,7 +38,9 @@ func (f *fakeUserStore) UpdateUser(_ context.Context, u *api.User) error {
 func (f *fakeUserStore) GetUserByName(context.Context, string) (*api.User, error) {
 	return nil, errNoUser
 }
-func (f *fakeUserStore) ListUsers(context.Context, string) ([]api.User, error) { return nil, nil }
+func (f *fakeUserStore) ListUsers(context.Context, string, int, int) ([]api.User, error) {
+	return nil, nil
+}
 func (f *fakeUserStore) GetUserByAPIKeyHash(context.Context, string) (*api.User, error) {
 	return nil, errNoUser
 }
@@ -49,7 +51,9 @@ func (f *fakeUserStore) GetDepartment(context.Context, string) (*api.Department,
 func (f *fakeUserStore) GetDepartmentByName(context.Context, string) (*api.Department, error) {
 	return nil, errNoUser
 }
-func (f *fakeUserStore) ListDepartments(context.Context) ([]api.Department, error) { return nil, nil }
+func (f *fakeUserStore) ListDepartments(context.Context, int, int) ([]api.Department, error) {
+	return nil, nil
+}
 func (f *fakeUserStore) UpdateDepartment(context.Context, *api.Department) error   { return nil }
 func (f *fakeUserStore) DeleteDepartment(context.Context, string) error            { return nil }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,6 +171,12 @@ type RateLimitConfig struct {
 	Enabled           bool    `yaml:"enabled"`           // Enable rate limiting (default: false)
 	RequestsPerSecond float64 `yaml:"requestsPerSecond"` // Steady-state rate per client (default: 10)
 	Burst             int     `yaml:"burst"`             // Max burst size per client (default: 20)
+	// WriteRequestsPerSecond / WriteBurst bound expensive mutating verbs
+	// (deploy/create/update/delete) with a stricter per-client budget than
+	// reads, so a single user can't flood the deploy path. <=0 falls back to a
+	// safe default (1 rps / burst 5).
+	WriteRequestsPerSecond float64 `yaml:"writeRequestsPerSecond"`
+	WriteBurst             int     `yaml:"writeBurst"`
 }
 
 type DeploymentConfig struct {
@@ -291,8 +297,10 @@ func Default() *Config {
 			LogFormat: "text",
 			LogLevel:  "info",
 			RateLimit: RateLimitConfig{
-				RequestsPerSecond: 10,
-				Burst:             20,
+				RequestsPerSecond:      10,
+				Burst:                  20,
+				WriteRequestsPerSecond: 1,
+				WriteBurst:             5,
 			},
 		},
 		Deployment: DeploymentConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,14 @@ type AuthConfig struct {
 	// direct client cannot spoof a user by setting the header. Ignored by the
 	// apikey/oidc modes.
 	TrustedProxies []string `yaml:"trustedProxies,omitempty"`
+
+	// DevInsecure must be set to true to run with auth disabled
+	// (enabled=false) on a non-loopback bind. Without it the server refuses to
+	// start in that configuration, because auth-disabled mode treats every
+	// request as admin and a non-loopback bind would expose the full admin API
+	// unauthenticated to the network. Intended only for trusted/network-isolated
+	// environments (local dev, or an in-cluster bind fronted by NetworkPolicy).
+	DevInsecure bool `yaml:"devInsecure,omitempty"`
 	// Options is a generic bag read by out-of-tree auth providers. Core providers
 	// (apikey/oauth/oidc) ignore it, so a new mode needs no field added to this
 	// struct.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,10 +65,15 @@ type LimitsConfig struct {
 	MaxFileCount     int `yaml:"maxFileCount"`     // Max number of files per deploy/update (default: 500)
 	MaxLogLines      int `yaml:"maxLogLines"`      // Max log lines per request (default: 10000)
 	// MaxConcurrentLogStreamsPerUser caps simultaneous /v1/logs SSE streams a
-	// single authenticated user may hold open. 0 = unlimited (legacy). A
-	// modest default (10) blocks the trivial DoS where one user opens
-	// hundreds of streams to exhaust controller memory.
+	// single authenticated user may hold open. <=0 falls back to a safe server
+	// default (not unlimited): one user opening hundreds of streams is a
+	// trivial memory-exhaustion DoS.
 	MaxConcurrentLogStreamsPerUser int `yaml:"maxConcurrentLogStreamsPerUser"`
+	// MaxConcurrentLogStreamsGlobal caps simultaneous /v1/logs SSE streams
+	// across all users, so many users can't collectively exhaust controller
+	// memory while each stays under the per-user cap. <=0 falls back to a safe
+	// server default.
+	MaxConcurrentLogStreamsGlobal int `yaml:"maxConcurrentLogStreamsGlobal"`
 }
 
 // AuthConfig holds authentication and TLS settings.
@@ -328,6 +333,7 @@ func Default() *Config {
 			MaxFileCount:                   500,
 			MaxLogLines:                    10000,
 			MaxConcurrentLogStreamsPerUser: 10,
+			MaxConcurrentLogStreamsGlobal:  100,
 		},
 		GC: GCConfig{
 			Enabled:  true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,7 +255,10 @@ type RegistryConfig struct {
 }
 
 type StoreConfig struct {
-	Backend   string          `yaml:"backend"` // "sqlite" (default), "memory", or "configmap"
+	// Backend: "sqlite" (default, recommended — scales per-row), "memory", or
+	// "configmap" (small/dev deployments only; all artifacts share one ConfigMap
+	// bounded by etcd's ~1MB object ceiling — see internal/store/configmap.go).
+	Backend   string          `yaml:"backend"`
 	ConfigMap ConfigMapConfig `yaml:"configmap"`
 	SQLite    SQLiteConfig    `yaml:"sqlite"`
 	// Options is a generic bag passed verbatim to the store backend factory.

--- a/internal/controller/backoff_test.go
+++ b/internal/controller/backoff_test.go
@@ -1,0 +1,53 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
+)
+
+func readyCond(status metav1.ConditionStatus, since time.Time) vibedv1.VibedApp {
+	return vibedv1.VibedApp{
+		Status: vibedv1.VibedAppStatus{
+			Conditions: []metav1.Condition{{
+				Type:               ConditionReady,
+				Status:             status,
+				LastTransitionTime: metav1.NewTime(since),
+			}},
+		},
+	}
+}
+
+// TestTransitionalRequeueBackoff locks in issue #70: transitional requeues start
+// near RequeueDelay and back off exponentially (capped) the longer an app has
+// been non-Ready, instead of a flat hot-poll forever.
+func TestTransitionalRequeueBackoff(t *testing.T) {
+	r := &Reconciler{RequeueDelay: 2 * time.Second}
+	now := time.Now()
+
+	cases := []struct {
+		name string
+		app  vibedv1.VibedApp
+		want time.Duration
+	}{
+		{"no Ready condition yet → base", vibedv1.VibedApp{}, 2 * time.Second},
+		{"currently Ready → base", readyCond(metav1.ConditionTrue, now.Add(-time.Hour)), 2 * time.Second},
+		{"just went not-Ready → base", readyCond(metav1.ConditionFalse, now), 2 * time.Second},
+		{"not-Ready ~6s (3 periods) → 16s", readyCond(metav1.ConditionFalse, now.Add(-6 * time.Second)), 16 * time.Second},
+		{"long-stuck → capped at max", readyCond(metav1.ConditionFalse, now.Add(-10 * time.Minute)), maxRequeueDelay},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := r.transitionalRequeueAfter(&c.app)
+			if got != c.want {
+				t.Errorf("transitionalRequeueAfter = %s, want %s", got, c.want)
+			}
+			if got > maxRequeueDelay {
+				t.Errorf("backoff %s exceeded the cap %s", got, maxRequeueDelay)
+			}
+		})
+	}
+}

--- a/internal/controller/vibedapp_controller.go
+++ b/internal/controller/vibedapp_controller.go
@@ -229,6 +229,53 @@ func (r *Reconciler) applyDefaults() {
 	}
 }
 
+// maxRequeueDelay caps the exponential backoff for transitional-phase requeues.
+const maxRequeueDelay = 60 * time.Second
+
+// transitionalRequeueAfter returns a capped exponential backoff for re-checking
+// an app that's still working toward Ready. It starts at RequeueDelay and
+// doubles for every RequeueDelay of elapsed not-Ready time, so a brief
+// transition re-checks promptly while an app wedged in Claiming (warm pool
+// exhausted) or Starting (slow agent) backs off toward maxRequeueDelay instead
+// of hot-polling every RequeueDelay forever (#70). The SandboxClaim watch still
+// delivers the real Claiming->Ready wakeup, so a longer safety-net requeue does
+// not slow genuine progress.
+func (r *Reconciler) transitionalRequeueAfter(app *vibedv1.VibedApp) time.Duration {
+	base := r.RequeueDelay
+	if base <= 0 {
+		base = 2 * time.Second
+	}
+	d := base
+	for periods := int(notReadyFor(app, time.Now()) / base); periods > 0 && d < maxRequeueDelay; periods-- {
+		d *= 2
+	}
+	if d > maxRequeueDelay {
+		d = maxRequeueDelay
+	}
+	return d
+}
+
+// notReadyFor reports how long app's Ready condition has been non-True (0 when
+// it has no Ready condition yet or is currently Ready). setCondition only bumps
+// LastTransitionTime when the status flips, so this measures continuous
+// not-Ready time across the transitional phases, which is the right "how long
+// stuck" signal for backoff.
+func notReadyFor(app *vibedv1.VibedApp, now time.Time) time.Duration {
+	for _, c := range app.Status.Conditions {
+		if c.Type != ConditionReady {
+			continue
+		}
+		if c.Status == metav1.ConditionTrue || c.LastTransitionTime.IsZero() {
+			return 0
+		}
+		if d := now.Sub(c.LastTransitionTime.Time); d > 0 {
+			return d
+		}
+		return 0
+	}
+	return 0
+}
+
 // Reconcile drives the state machine forward by one step.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	r.applyDefaults()
@@ -251,6 +298,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Snapshot status so we only patch if something changed.
 	before := app.Status.DeepCopy()
+
+	// Backoff for any transitional-phase requeue below, derived from how long
+	// the app has already been non-Ready (see transitionalRequeueAfter).
+	requeueAfter := r.transitionalRequeueAfter(&app)
 
 	// Validation gate. Failure here is terminal until the user updates spec.
 	if err := validateSpec(&app.Spec); err != nil {
@@ -314,7 +365,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		if !bound {
 			// SandboxClaim exists but agent-sandbox hasn't bound a pod yet.
@@ -324,7 +375,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		app.Status.SandboxRef = sandboxRef
 		app.Status.PodIP = podIP
@@ -349,12 +400,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		if !ready {
 			// Agent reachable but user process not yet listening — requeue
 			// without rewriting status (nothing changed).
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		// Agent is up — inject the user's source (refactor.md §5.3 step 2).
 		// The agent pulls the tarball from spec.source.tarballRef and starts
@@ -366,14 +417,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		if !running {
 			setCondition(&app, ConditionReady, metav1.ConditionFalse, ReasonStarting, "user process starting")
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		// Publish a stable upstream for the router: a per-app Service that
 		// re-selects the bound pod across restarts, so the route doesn't go
@@ -384,7 +435,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		app.Status.RouteTarget = routeTarget
 		url, err := r.Router.Publish(ctx, &app, app.Status.SandboxRef)
@@ -393,7 +444,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if perr := r.patchStatusIfChanged(ctx, &app, before); perr != nil {
 				return reconcile.Result{}, perr
 			}
-			return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		app.Status.URL = url
 		app.Status.Phase = vibedv1.PhaseReady
@@ -444,6 +495,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 // handled=false and the caller continues normal reconciliation.
 func (r *Reconciler) reconcileSuspension(ctx context.Context, app *vibedv1.VibedApp, before *vibedv1.VibedAppStatus) (bool, reconcile.Result, error) {
 	logger := log.FromContext(ctx)
+	requeueAfter := r.transitionalRequeueAfter(app)
 
 	if app.Spec.Suspended {
 		if app.Status.Phase == vibedv1.PhaseSuspended {
@@ -462,7 +514,7 @@ func (r *Reconciler) reconcileSuspension(ctx context.Context, app *vibedv1.Vibed
 			if perr := r.patchStatusIfChanged(ctx, app, before); perr != nil {
 				return true, reconcile.Result{}, perr
 			}
-			return true, reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+			return true, reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		app.Status.PodIP = ""
 		app.Status.SandboxRef = ""
@@ -503,6 +555,7 @@ func isWorkerdFastLane(app *vibedv1.VibedApp) bool {
 // no Claiming/Starting — workerd is always running, so a successful deploy is
 // immediately Ready.
 func (r *Reconciler) reconcileFastLane(ctx context.Context, app *vibedv1.VibedApp, before *vibedv1.VibedAppStatus) (reconcile.Result, error) {
+	requeueAfter := r.transitionalRequeueAfter(app)
 	// Steady state: nothing to do once Ready (a spec change bumps generation
 	// and the loader Deploy below is idempotent, so re-running is harmless,
 	// but we avoid the work when already serving).
@@ -517,7 +570,7 @@ func (r *Reconciler) reconcileFastLane(ctx context.Context, app *vibedv1.VibedAp
 		if perr := r.patchStatusIfChanged(ctx, app, before); perr != nil {
 			return reconcile.Result{}, perr
 		}
-		return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	url, err := r.Router.Publish(ctx, app, target)
@@ -526,7 +579,7 @@ func (r *Reconciler) reconcileFastLane(ctx context.Context, app *vibedv1.VibedAp
 		if perr := r.patchStatusIfChanged(ctx, app, before); perr != nil {
 			return reconcile.Result{}, perr
 		}
-		return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	// RouteTarget carries the routable upstream. For the fast lane it's the
@@ -545,11 +598,12 @@ func (r *Reconciler) reconcileFastLane(ctx context.Context, app *vibedv1.VibedAp
 // requeue. requeue=true means we're mid-state-machine and a follow-up
 // reconcile is needed even if nothing external pings us.
 func (r *Reconciler) finish(ctx context.Context, app *vibedv1.VibedApp, before *vibedv1.VibedAppStatus, requeue bool) (reconcile.Result, error) {
+	requeueAfter := r.transitionalRequeueAfter(app)
 	if err := r.patchStatusIfChanged(ctx, app, before); err != nil {
 		return reconcile.Result{}, err
 	}
 	if requeue {
-		return reconcile.Result{RequeueAfter: r.RequeueDelay}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 	return reconcile.Result{}, nil
 }

--- a/internal/deploy/logs.go
+++ b/internal/deploy/logs.go
@@ -66,7 +66,16 @@ func (s *Service) boundPodName(ctx context.Context, app *vibedv1.VibedApp) (stri
 	if app.Status.PodIP == "" {
 		return "", ErrNoPod
 	}
-	pods, err := s.Clientset.CoreV1().Pods(app.Namespace).List(ctx, metav1.ListOptions{LabelSelector: sandboxPodLabel})
+	// Narrow to the one bound pod server-side via a field selector on status.podIP
+	// instead of listing every sandbox pod in the namespace and scanning by IP on
+	// each log-stream open (#77). The exact-IP check below stays as a backstop:
+	// clients that don't honor the field selector (e.g. the fake used in tests)
+	// just return the wider set and we match in Go, so correctness never depends
+	// on server-side field filtering.
+	pods, err := s.Clientset.CoreV1().Pods(app.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: sandboxPodLabel,
+		FieldSelector: "status.podIP=" + app.Status.PodIP,
+	})
 	if err != nil {
 		return "", fmt.Errorf("list bound pods: %w", err)
 	}

--- a/internal/deploy/query.go
+++ b/internal/deploy/query.go
@@ -81,16 +81,18 @@ func (s *Service) List(ctx context.Context, owner string) ([]vibedv1.VibedApp, e
 	if err != nil {
 		return nil, fmt.Errorf("resolve tenant: %w", err)
 	}
-	// Pre-filter server-side by the owner label so the API server returns only
-	// this owner's apps instead of every app in the namespace. The label is a
-	// sanitized, lossy mirror of spec.owner (distinct owners can collide onto one
-	// label value — see #66), so it can only over-return, never drop a match; the
-	// exact spec.owner check below is still authoritative.
+	listOpts := []client.ListOption{client.InNamespace(t.Namespace)}
+	// Without an Authorizer, List is owner-only, so pre-filter server-side by the
+	// owner label (#74) instead of fetching the whole namespace. The label is a
+	// lossy mirror of spec.owner (collisions possible — #66), so it can only
+	// over-return; the exact spec.owner check below stays authoritative. With an
+	// Authorizer we must fetch every app in the namespace so it can grant
+	// team-scoped visibility (apps the caller doesn't own), so skip the pre-filter.
+	if s.Authz == nil {
+		listOpts = append(listOpts, client.MatchingLabels{vibedv1.LabelOwner: vibedv1.SanitizeLabel(owner)})
+	}
 	var list vibedv1.VibedAppList
-	if err := s.Client.List(ctx, &list,
-		client.InNamespace(t.Namespace),
-		client.MatchingLabels{vibedv1.LabelOwner: vibedv1.SanitizeLabel(owner)},
-	); err != nil {
+	if err := s.Client.List(ctx, &list, listOpts...); err != nil {
 		return nil, fmt.Errorf("list VibedApps: %w", err)
 	}
 	out := make([]vibedv1.VibedApp, 0, len(list.Items))

--- a/internal/deploy/query.go
+++ b/internal/deploy/query.go
@@ -48,8 +48,16 @@ func (s *Service) List(ctx context.Context, owner string) ([]vibedv1.VibedApp, e
 	if err != nil {
 		return nil, fmt.Errorf("resolve tenant: %w", err)
 	}
+	// Pre-filter server-side by the owner label so the API server returns only
+	// this owner's apps instead of every app in the namespace. The label is a
+	// sanitized, lossy mirror of spec.owner (distinct owners can collide onto one
+	// label value — see #66), so it can only over-return, never drop a match; the
+	// exact spec.owner check below is still authoritative.
 	var list vibedv1.VibedAppList
-	if err := s.Client.List(ctx, &list, client.InNamespace(t.Namespace)); err != nil {
+	if err := s.Client.List(ctx, &list,
+		client.InNamespace(t.Namespace),
+		client.MatchingLabels{vibedv1.LabelOwner: vibedv1.SanitizeLabel(owner)},
+	); err != nil {
 		return nil, fmt.Errorf("list VibedApps: %w", err)
 	}
 	out := make([]vibedv1.VibedApp, 0, len(list.Items))

--- a/internal/deploy/service.go
+++ b/internal/deploy/service.go
@@ -87,9 +87,12 @@ type Service struct {
 }
 
 // Quota gates new deploys within a tenant and resolves the owner's department
-// (for labeling).
+// (for labeling). Authorize returns a non-nil release the caller must invoke
+// once the new app is durably created (List-visible) or the deploy has failed;
+// it drops the reservation Authorize took against the ceiling, which is what
+// keeps concurrent deploys from overshooting it.
 type Quota interface {
-	Authorize(ctx context.Context, t tenant.Tenant, owner string, isNew bool) (department string, err error)
+	Authorize(ctx context.Context, t tenant.Tenant, owner string, isNew bool) (department string, release func(), err error)
 }
 
 // Auditor records a mutating action; implementations read the actor from ctx.
@@ -241,14 +244,21 @@ func (s *Service) Deploy(ctx context.Context, req Request) (*Result, error) {
 	}
 
 	// Quota gates new deploys (within the tenant) and tells us the owner's
-	// department for labeling.
+	// department for labeling. The reservation Authorize takes must be released
+	// once the new app is durably created (List-visible via the direct client)
+	// or the deploy fails — releaseQuota, called both after the CR write and via
+	// defer, does that; it's idempotent, so the defer is a safety net for the
+	// error paths in between.
 	var department string
+	releaseQuota := func() {}
+	defer func() { releaseQuota() }()
 	if s.Quota != nil {
-		dept, qerr := s.Quota.Authorize(ctx, t, req.Owner, isNew)
+		dept, release, qerr := s.Quota.Authorize(ctx, t, req.Owner, isNew)
 		if qerr != nil {
 			_ = s.record(ctx, "deploy", req.Name, "denied", qerr.Error())
 			return nil, qerr
 		}
+		releaseQuota = release
 		department = dept
 	}
 
@@ -335,6 +345,12 @@ func (s *Service) Deploy(ctx context.Context, req Request) (*Result, error) {
 			return nil, fmt.Errorf("update VibedApp: %w", uerr)
 		}
 	}
+
+	// The CR is durably written and now List-visible via the direct client, so
+	// the quota reservation is redundant with the live count — drop it promptly
+	// (rather than only on the deferred path after waitReady) so it isn't
+	// double-counted against a concurrent deploy at the exact ceiling boundary.
+	releaseQuota()
 
 	// Prune source tarballs for versions that aged out of the retained history.
 	for _, k := range evicted {

--- a/internal/deploy/service.go
+++ b/internal/deploy/service.go
@@ -157,16 +157,21 @@ func (s *Service) Deploy(ctx context.Context, req Request) (*Result, error) {
 		return nil, fmt.Errorf("resolve tenant: %w", err)
 	}
 
-	// Read + cap the tarball once; we feed the same bytes to the classifier
-	// and the store.
-	buf, err := readCapped(req.Tarball, MaxTarballBytes)
+	// Read + cap the tarball once, hashing it in the same pass via a TeeReader
+	// instead of walking the full (up-to-50MB) buffer a second time with
+	// sha256.Sum256 — this is the latency-sensitive deploy hot path (#73). The
+	// buffer is still needed in memory because the policy engine evaluates over
+	// the full source bytes; the remaining passes (classify, store upload) are
+	// inherent to those operations.
+	hasher := sha256.New()
+	buf, err := readCapped(io.TeeReader(req.Tarball, hasher), MaxTarballBytes)
 	if err != nil {
 		return nil, err
 	}
 
 	// Enrich the audit events for this deploy with the tenant and a hash of the
 	// exact source (provenance). The context flows through every s.record call.
-	sum := sha256.Sum256(buf)
+	sum := hasher.Sum(nil)
 	ctx = audit.WithFields(ctx, audit.Fields{TenantID: t.ID, SourceHash: hex.EncodeToString(sum[:])})
 
 	// Classify (unless both lane + template are overridden).

--- a/internal/deploy/service_test.go
+++ b/internal/deploy/service_test.go
@@ -301,12 +301,27 @@ func TestDeployHonorsOverride(t *testing.T) {
 	}
 }
 
+// ownedApp builds a VibedApp with the vibed.dev/owner label the deploy path
+// stamps, so tests exercising the label-filtered List behave like production.
+func ownedApp(name, namespace, owner string) *vibedv1.VibedApp {
+	return &vibedv1.VibedApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{vibedv1.LabelOwner: vibedv1.SanitizeLabel(owner)},
+		},
+		Spec: vibedv1.VibedAppSpec{Owner: owner},
+	}
+}
+
 func TestGetListDeleteOwnership(t *testing.T) {
 	s := newScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&vibedv1.VibedApp{}).
 		WithObjects(
-			&vibedv1.VibedApp{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "vibed-apps"}, Spec: vibedv1.VibedAppSpec{Owner: "alice"}},
-			&vibedv1.VibedApp{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "vibed-apps"}, Spec: vibedv1.VibedAppSpec{Owner: "bob"}},
+			// Apps carry the vibed.dev/owner label the deploy path stamps, so
+			// List's server-side owner pre-filter (#74) selects them.
+			ownedApp("a", "vibed-apps", "alice"),
+			ownedApp("b", "vibed-apps", "bob"),
 		).Build()
 	svc := newService(c, newFakeStore())
 

--- a/internal/deploy/service_test.go
+++ b/internal/deploy/service_test.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -585,10 +587,16 @@ func TestDeployEnrichesAuditWithTenantAndSourceHash(t *testing.T) {
 	svc.Tenants = tenant.Single(tenant.Tenant{ID: "acme", Namespace: "tenant-acme"})
 	markReady(c, "app1", "tenant-acme", 20*time.Millisecond)
 
+	// Capture the exact source bytes so we can assert the deploy path hashes the
+	// whole tarball correctly — the hash is now computed in the read pass via a
+	// TeeReader (#73), so a truncated or double-counted read would show here.
+	tarball := gzTarball(t, map[string]string{"index.html": "x"})
+	wantHash := fmt.Sprintf("%x", sha256.Sum256(tarball))
+
 	if _, err := svc.Deploy(context.Background(), Request{
 		Name:    "app1",
 		Owner:   "alice",
-		Tarball: bytes.NewReader(gzTarball(t, map[string]string{"index.html": "x"})),
+		Tarball: bytes.NewReader(tarball),
 	}); err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
@@ -611,8 +619,8 @@ func TestDeployEnrichesAuditWithTenantAndSourceHash(t *testing.T) {
 	if dep.Action != "deploy" || dep.TenantID != "acme" {
 		t.Errorf("deploy event = %+v, want tenant acme", dep)
 	}
-	if dep.SourceHash == "" {
-		t.Error("deploy event should carry a non-empty SourceHash")
+	if dep.SourceHash != wantHash {
+		t.Errorf("deploy event SourceHash = %q, want sha256 of the tarball %q", dep.SourceHash, wantHash)
 	}
 	// Delete has no source, so no hash.
 	if del.SourceHash != "" {

--- a/internal/deploy/service_test.go
+++ b/internal/deploy/service_test.go
@@ -465,17 +465,19 @@ func TestMeterRecordsDeployAndDelete(t *testing.T) {
 }
 
 type fakeQuota struct {
-	dept    string
-	deny    bool
-	lastNew bool
+	dept     string
+	deny     bool
+	lastNew  bool
+	released int // times the returned release func was invoked
 }
 
-func (q *fakeQuota) Authorize(_ context.Context, _ tenant.Tenant, _ string, isNew bool) (string, error) {
+func (q *fakeQuota) Authorize(_ context.Context, _ tenant.Tenant, _ string, isNew bool) (string, func(), error) {
 	q.lastNew = isNew
+	release := func() { q.released++ }
 	if q.deny {
-		return q.dept, &fakeQuotaErr{}
+		return q.dept, release, &fakeQuotaErr{}
 	}
-	return q.dept, nil
+	return q.dept, release, nil
 }
 
 type fakeQuotaErr struct{}

--- a/internal/deploy/sharelinks.go
+++ b/internal/deploy/sharelinks.go
@@ -60,15 +60,16 @@ func (s *Service) CreateShareLink(ctx context.Context, owner, appID, password st
 	return link, nil
 }
 
-// ListShareLinks returns the app's share links if owner owns it.
-func (s *Service) ListShareLinks(ctx context.Context, owner, appID string) ([]api.ShareLink, error) {
+// ListShareLinks returns the app's share links if owner owns it. limit<=0
+// returns all; limit>0 pages with offset.
+func (s *Service) ListShareLinks(ctx context.Context, owner, appID string, limit, offset int) ([]api.ShareLink, error) {
 	if s.ShareLinks == nil {
 		return nil, fmt.Errorf("share links require the sqlite store backend")
 	}
 	if _, err := s.Get(ctx, owner, appID); err != nil {
 		return nil, err
 	}
-	return s.ShareLinks.ListShareLinks(ctx, appID)
+	return s.ShareLinks.ListShareLinks(ctx, appID, limit, offset)
 }
 
 // RevokeShareLink revokes a token if owner owns the app it points at.

--- a/internal/deploy/sharelinks_test.go
+++ b/internal/deploy/sharelinks_test.go
@@ -38,12 +38,20 @@ func (f *fakeShareLinkStore) GetShareLink(_ context.Context, t string) (*api.Sha
 	return l, f.hash[t], nil
 }
 
-func (f *fakeShareLinkStore) ListShareLinks(_ context.Context, artifactID string) ([]api.ShareLink, error) {
+func (f *fakeShareLinkStore) ListShareLinks(_ context.Context, artifactID string, limit, offset int) ([]api.ShareLink, error) {
 	var out []api.ShareLink
 	for _, l := range f.links {
 		if l.ArtifactID == artifactID {
 			out = append(out, *l)
 		}
+	}
+	if offset > 0 && offset < len(out) {
+		out = out[offset:]
+	} else if offset >= len(out) {
+		out = nil
+	}
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
 	}
 	return out, nil
 }
@@ -92,7 +100,7 @@ func TestShareLinks(t *testing.T) {
 		t.Fatal("expected error for non-owner create")
 	}
 
-	links, err := svc.ListShareLinks(context.Background(), "alice@example.com", "shareapp")
+	links, err := svc.ListShareLinks(context.Background(), "alice@example.com", "shareapp", 0, 0)
 	if err != nil || len(links) != 1 {
 		t.Fatalf("list: err=%v n=%d", err, len(links))
 	}

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -787,9 +787,12 @@ func handleArtifactShareLinks(orch *orchestrator.Orchestrator, deploySvc *deploy
 		return
 	}
 
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
 	owner := vibedauth.UserIDFromContext(r.Context())
 	if deploySvc != nil && deploySvc.ShareLinks != nil && owner != "" {
-		links, derr := deploySvc.ListShareLinks(r.Context(), owner, artifactID)
+		links, derr := deploySvc.ListShareLinks(r.Context(), owner, artifactID, limit, offset)
 		if derr == nil {
 			if links == nil {
 				links = []api.ShareLink{}
@@ -804,7 +807,7 @@ func handleArtifactShareLinks(orch *orchestrator.Orchestrator, deploySvc *deploy
 		}
 	}
 
-	links, err := orch.ListShareLinks(r.Context(), artifactID)
+	links, err := orch.ListShareLinks(r.Context(), artifactID, limit, offset)
 	if err != nil {
 		writeError(w, err, http.StatusBadRequest)
 		return

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -372,7 +372,9 @@ func handleUsers(userStore store.UserStore) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			departmentID := r.URL.Query().Get("department")
-			users, err := userStore.ListUsers(r.Context(), departmentID)
+			limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+			users, err := userStore.ListUsers(r.Context(), departmentID, limit, offset)
 			if err != nil {
 				writeError(w, err, http.StatusInternalServerError)
 				return
@@ -543,7 +545,9 @@ func handleDepartments(userStore store.UserStore, k8sClients *k8s.Clients) http.
 
 		switch r.Method {
 		case http.MethodGet:
-			depts, err := userStore.ListDepartments(r.Context())
+			limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+			depts, err := userStore.ListDepartments(r.Context(), limit, offset)
 			if err != nil {
 				writeError(w, err, http.StatusInternalServerError)
 				return

--- a/internal/gc/collector.go
+++ b/internal/gc/collector.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +22,46 @@ import (
 	"github.com/vibed-project/vibeD/internal/store"
 	"github.com/vibed-project/vibeD/pkg/api"
 )
+
+const (
+	// gcListPageSize bounds how many objects each GC List pulls per request, so
+	// a large orphan backlog is streamed a page at a time instead of loaded
+	// whole into memory (#76).
+	gcListPageSize = 200
+	// gcDeleteConcurrency bounds in-flight deletes per sweep so a backlog is
+	// cleared with bounded parallelism instead of one blocking call at a time.
+	gcDeleteConcurrency = 8
+	// gcDeleteTimeout caps a single delete so one slow API call can't stall the
+	// sweep and starve the next GC cycle.
+	gcDeleteTimeout = 30 * time.Second
+)
+
+// deleteRunner runs per-resource deletes on a bounded worker pool, each under a
+// per-delete timeout. Delete funcs are best-effort (they log their own errors),
+// so the pool never aborts early on a single failure.
+type deleteRunner struct {
+	g   *errgroup.Group
+	ctx context.Context
+}
+
+func newDeleteRunner(ctx context.Context) *deleteRunner {
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(gcDeleteConcurrency)
+	return &deleteRunner{g: g, ctx: gctx}
+}
+
+// run schedules one resource delete on the bounded pool with a per-delete
+// timeout. It blocks only when all workers are busy (errgroup SetLimit).
+func (d *deleteRunner) run(fn func(ctx context.Context)) {
+	d.g.Go(func() error {
+		ctx, cancel := context.WithTimeout(d.ctx, gcDeleteTimeout)
+		defer cancel()
+		fn(ctx)
+		return nil // best-effort: never cancel siblings on one failure
+	})
+}
+
+func (d *deleteRunner) wait() { _ = d.g.Wait() }
 
 const (
 	// labelManagedBy is used to identify vibeD-managed resources.
@@ -136,181 +177,205 @@ func (gc *GarbageCollector) cleanOrphanedSandboxes(ctx context.Context, activeAr
 		Resource: "sandboxes",
 	}
 
-	list, err := gc.dynamicClient.Resource(sandboxGVR).Namespace(gc.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelManagedBy,
-	})
-	if err != nil {
-		// agent-sandbox CRD not installed in this cluster: silent skip.
-		if k8serrors.IsNotFound(err) {
-			return
-		}
-		gc.logger.Warn("failed to list sandboxes for GC", "error", err)
-		return
-	}
-
-	for _, sb := range list.Items {
-		labels := sb.GetLabels()
-		artifactID := labels[labelArtifactID]
-		if artifactID == "" {
-			continue
-		}
-		if activeArtifacts[artifactID] {
-			continue
-		}
-
-		if gc.dryRun {
-			gc.logger.Info("dry-run: would delete orphaned sandbox", "sandbox", sb.GetName(), "artifactID", artifactID)
-			continue
-		}
-
-		if err := gc.dynamicClient.Resource(sandboxGVR).Namespace(gc.namespace).Delete(ctx, sb.GetName(), metav1.DeleteOptions{}); err != nil {
+	runner := newDeleteRunner(ctx)
+	opts := metav1.ListOptions{LabelSelector: labelManagedBy, Limit: gcListPageSize}
+	for {
+		list, err := gc.dynamicClient.Resource(sandboxGVR).Namespace(gc.namespace).List(ctx, opts)
+		if err != nil {
+			// agent-sandbox CRD not installed in this cluster: silent skip.
 			if k8serrors.IsNotFound(err) {
+				return
+			}
+			gc.logger.Warn("failed to list sandboxes for GC", "error", err)
+			break
+		}
+
+		for _, sb := range list.Items {
+			artifactID := sb.GetLabels()[labelArtifactID]
+			if artifactID == "" || activeArtifacts[artifactID] {
 				continue
 			}
-			gc.logger.Warn("failed to delete orphaned sandbox", "sandbox", sb.GetName(), "error", err)
-			continue
+			if gc.dryRun {
+				gc.logger.Info("dry-run: would delete orphaned sandbox", "sandbox", sb.GetName(), "artifactID", artifactID)
+				continue
+			}
+			name := sb.GetName()
+			runner.run(func(ctx context.Context) {
+				if err := gc.dynamicClient.Resource(sandboxGVR).Namespace(gc.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+					if k8serrors.IsNotFound(err) {
+						return
+					}
+					gc.logger.Warn("failed to delete orphaned sandbox", "sandbox", name, "error", err)
+					return
+				}
+				gc.metrics.GCResourcesCleaned.WithLabelValues("sandbox").Inc()
+				gc.logger.Info("deleted orphaned sandbox", "sandbox", name, "artifactID", artifactID)
+			})
 		}
-		gc.metrics.GCResourcesCleaned.WithLabelValues("sandbox").Inc()
-		gc.logger.Info("deleted orphaned sandbox", "sandbox", sb.GetName(), "artifactID", artifactID)
+
+		if list.GetContinue() == "" {
+			break
+		}
+		opts.Continue = list.GetContinue()
 	}
+	runner.wait()
 }
 
 // cleanOrphanedJobs deletes completed/failed build Jobs whose artifact
 // no longer exists in the store, or that are older than maxAge.
 func (gc *GarbageCollector) cleanOrphanedJobs(ctx context.Context, activeArtifacts map[string]bool) {
 	selector := labelManagedBy + "," + labelComponent + "=build"
-	jobs, err := gc.clientset.BatchV1().Jobs(gc.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: selector,
-	})
-	if err != nil {
-		gc.logger.Warn("failed to list jobs for GC", "error", err)
-		return
+	runner := newDeleteRunner(ctx)
+	opts := metav1.ListOptions{LabelSelector: selector, Limit: gcListPageSize}
+	for {
+		jobs, err := gc.clientset.BatchV1().Jobs(gc.namespace).List(ctx, opts)
+		if err != nil {
+			gc.logger.Warn("failed to list jobs for GC", "error", err)
+			break
+		}
+
+		for i := range jobs.Items {
+			job := jobs.Items[i]
+			// Skip running jobs.
+			if !isJobFinished(&job) {
+				continue
+			}
+
+			artifactID := job.Labels[labelArtifactID]
+			if artifactID == "" {
+				continue
+			}
+
+			age := time.Since(job.CreationTimestamp.Time)
+			if age < gc.maxAge {
+				continue
+			}
+			// A finished job past maxAge is collected whether its artifact is gone
+			// (orphaned) or still present (stale build job).
+
+			if gc.dryRun {
+				gc.logger.Info("dry-run: would delete orphaned job", "job", job.Name, "artifactID", artifactID, "age", age)
+				continue
+			}
+
+			name := job.Name
+			runner.run(func(ctx context.Context) {
+				propagation := metav1.DeletePropagationBackground
+				if err := gc.clientset.BatchV1().Jobs(gc.namespace).Delete(ctx, name, metav1.DeleteOptions{
+					PropagationPolicy: &propagation,
+				}); err != nil {
+					gc.logger.Warn("failed to delete orphaned job", "job", name, "error", err)
+					return
+				}
+				gc.metrics.GCResourcesCleaned.WithLabelValues("job").Inc()
+				gc.logger.Info("deleted orphaned job", "job", name, "artifactID", artifactID)
+			})
+		}
+
+		if jobs.Continue == "" {
+			break
+		}
+		opts.Continue = jobs.Continue
 	}
-
-	for _, job := range jobs.Items {
-		// Skip running jobs.
-		if !isJobFinished(&job) {
-			continue
-		}
-
-		artifactID := job.Labels[labelArtifactID]
-		if artifactID == "" {
-			continue
-		}
-
-		age := time.Since(job.CreationTimestamp.Time)
-		if age < gc.maxAge {
-			continue
-		}
-
-		// Check if the artifact still exists.
-		exists := activeArtifacts[artifactID]
-		orphaned := !exists
-		stale := exists // artifact exists but job is old and finished
-
-		if !orphaned && !stale {
-			continue
-		}
-
-		if gc.dryRun {
-			gc.logger.Info("dry-run: would delete orphaned job", "job", job.Name, "artifactID", artifactID, "age", age)
-			continue
-		}
-
-		propagation := metav1.DeletePropagationBackground
-		if err := gc.clientset.BatchV1().Jobs(gc.namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
-			PropagationPolicy: &propagation,
-		}); err != nil {
-			gc.logger.Warn("failed to delete orphaned job", "job", job.Name, "error", err)
-			continue
-		}
-		gc.metrics.GCResourcesCleaned.WithLabelValues("job").Inc()
-		gc.logger.Info("deleted orphaned job", "job", job.Name, "artifactID", artifactID)
-	}
+	runner.wait()
 }
 
 // cleanOrphanedConfigMaps deletes ConfigMaps whose artifact no longer exists.
 func (gc *GarbageCollector) cleanOrphanedConfigMaps(ctx context.Context, activeArtifacts map[string]bool) {
 	selector := labelManagedBy + "," + labelArtifactID
-	cms, err := gc.clientset.CoreV1().ConfigMaps(gc.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: selector,
-	})
-	if err != nil {
-		gc.logger.Warn("failed to list configmaps for GC", "error", err)
-		return
+	runner := newDeleteRunner(ctx)
+	opts := metav1.ListOptions{LabelSelector: selector, Limit: gcListPageSize}
+	for {
+		cms, err := gc.clientset.CoreV1().ConfigMaps(gc.namespace).List(ctx, opts)
+		if err != nil {
+			gc.logger.Warn("failed to list configmaps for GC", "error", err)
+			break
+		}
+
+		for _, cm := range cms.Items {
+			// Skip artifact-store ConfigMaps (metadata store, not deploy CMs).
+			if cm.Labels[labelStoreComponent] == "artifact-store" {
+				continue
+			}
+
+			artifactID := cm.Labels[labelArtifactID]
+			if artifactID == "" || activeArtifacts[artifactID] {
+				continue
+			}
+
+			if gc.dryRun {
+				gc.logger.Info("dry-run: would delete orphaned configmap", "configmap", cm.Name, "artifactID", artifactID)
+				continue
+			}
+
+			name := cm.Name
+			runner.run(func(ctx context.Context) {
+				if err := gc.clientset.CoreV1().ConfigMaps(gc.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+					gc.logger.Warn("failed to delete orphaned configmap", "configmap", name, "error", err)
+					return
+				}
+				gc.metrics.GCResourcesCleaned.WithLabelValues("configmap").Inc()
+				gc.logger.Info("deleted orphaned configmap", "configmap", name, "artifactID", artifactID)
+			})
+		}
+
+		if cms.Continue == "" {
+			break
+		}
+		opts.Continue = cms.Continue
 	}
-
-	for _, cm := range cms.Items {
-		// Skip artifact-store ConfigMaps (metadata store, not deploy CMs).
-		if cm.Labels[labelStoreComponent] == "artifact-store" {
-			continue
-		}
-
-		artifactID := cm.Labels[labelArtifactID]
-		if artifactID == "" {
-			continue
-		}
-
-		if activeArtifacts[artifactID] {
-			continue
-		}
-
-		if gc.dryRun {
-			gc.logger.Info("dry-run: would delete orphaned configmap", "configmap", cm.Name, "artifactID", artifactID)
-			continue
-		}
-
-		if err := gc.clientset.CoreV1().ConfigMaps(gc.namespace).Delete(ctx, cm.Name, metav1.DeleteOptions{}); err != nil {
-			gc.logger.Warn("failed to delete orphaned configmap", "configmap", cm.Name, "error", err)
-			continue
-		}
-		gc.metrics.GCResourcesCleaned.WithLabelValues("configmap").Inc()
-		gc.logger.Info("deleted orphaned configmap", "configmap", cm.Name, "artifactID", artifactID)
-	}
+	runner.wait()
 }
 
 // cleanOrphanedDeployments deletes Deployments (and their matching Services)
 // whose artifact no longer exists in the store.
 func (gc *GarbageCollector) cleanOrphanedDeployments(ctx context.Context, activeArtifacts map[string]bool) {
-	deployments, err := gc.clientset.AppsV1().Deployments(gc.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelManagedBy,
-	})
-	if err != nil {
-		gc.logger.Warn("failed to list deployments for GC", "error", err)
-		return
+	runner := newDeleteRunner(ctx)
+	opts := metav1.ListOptions{LabelSelector: labelManagedBy, Limit: gcListPageSize}
+	for {
+		deployments, err := gc.clientset.AppsV1().Deployments(gc.namespace).List(ctx, opts)
+		if err != nil {
+			gc.logger.Warn("failed to list deployments for GC", "error", err)
+			break
+		}
+
+		for _, deploy := range deployments.Items {
+			artifactID := deploy.Labels[labelArtifactID]
+			if artifactID == "" || activeArtifacts[artifactID] {
+				continue
+			}
+
+			if gc.dryRun {
+				gc.logger.Info("dry-run: would delete orphaned deployment", "deployment", deploy.Name, "artifactID", artifactID)
+				continue
+			}
+
+			name := deploy.Name
+			runner.run(func(ctx context.Context) {
+				// Delete the Deployment.
+				if err := gc.clientset.AppsV1().Deployments(gc.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+					gc.logger.Warn("failed to delete orphaned deployment", "deployment", name, "error", err)
+					return
+				}
+				gc.metrics.GCResourcesCleaned.WithLabelValues("deployment").Inc()
+				gc.logger.Info("deleted orphaned deployment", "deployment", name, "artifactID", artifactID)
+
+				// Also delete the matching Service (same name convention used by the kubernetes deployer).
+				if err := gc.clientset.CoreV1().Services(gc.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+					gc.logger.Warn("failed to delete matching service", "service", name, "error", err)
+				} else {
+					gc.metrics.GCResourcesCleaned.WithLabelValues("service").Inc()
+					gc.logger.Info("deleted orphaned service", "service", name, "artifactID", artifactID)
+				}
+			})
+		}
+
+		if deployments.Continue == "" {
+			break
+		}
+		opts.Continue = deployments.Continue
 	}
-
-	for _, deploy := range deployments.Items {
-		artifactID := deploy.Labels[labelArtifactID]
-		if artifactID == "" {
-			continue
-		}
-
-		if activeArtifacts[artifactID] {
-			continue
-		}
-
-		if gc.dryRun {
-			gc.logger.Info("dry-run: would delete orphaned deployment", "deployment", deploy.Name, "artifactID", artifactID)
-			continue
-		}
-
-		// Delete the Deployment.
-		if err := gc.clientset.AppsV1().Deployments(gc.namespace).Delete(ctx, deploy.Name, metav1.DeleteOptions{}); err != nil {
-			gc.logger.Warn("failed to delete orphaned deployment", "deployment", deploy.Name, "error", err)
-			continue
-		}
-		gc.metrics.GCResourcesCleaned.WithLabelValues("deployment").Inc()
-		gc.logger.Info("deleted orphaned deployment", "deployment", deploy.Name, "artifactID", artifactID)
-
-		// Also delete the matching Service (same name convention used by kubernetes deployer).
-		if err := gc.clientset.CoreV1().Services(gc.namespace).Delete(ctx, deploy.Name, metav1.DeleteOptions{}); err != nil {
-			gc.logger.Warn("failed to delete matching service", "service", deploy.Name, "error", err)
-		} else {
-			gc.metrics.GCResourcesCleaned.WithLabelValues("service").Inc()
-			gc.logger.Info("deleted orphaned service", "service", deploy.Name, "artifactID", artifactID)
-		}
-	}
+	runner.wait()
 }
 
 // isJobFinished returns true if the Job has completed or failed.

--- a/internal/gc/collector_test.go
+++ b/internal/gc/collector_test.go
@@ -2,6 +2,7 @@ package gc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/vibed-project/vibeD/internal/config"
@@ -189,6 +191,28 @@ func TestGC_CleansOrphanedConfigMaps(t *testing.T) {
 	cms, err := clientset.CoreV1().ConfigMaps(testNamespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, cms.Items, "orphaned configmap should be deleted")
+}
+
+// TestGC_CleansManyOrphansConcurrently exercises the bounded-concurrency delete
+// path (#76) with far more orphans than the worker-pool limit: every orphan must
+// still be deleted (nothing dropped or double-processed), and the run must be
+// race-clean (go test -race).
+func TestGC_CleansManyOrphansConcurrently(t *testing.T) {
+	ctx := context.Background()
+	const n = 50 // > gcDeleteConcurrency
+	objs := make([]runtime.Object, 0, n)
+	for i := 0; i < n; i++ {
+		objs = append(objs, testConfigMap(fmt.Sprintf("vibed-cm-%d", i), fmt.Sprintf("gone-%d", i), nil))
+	}
+	clientset := fake.NewSimpleClientset(objs...)
+	st := store.NewMemoryStore() // no active artifacts → all orphaned
+
+	gc := newTestGC(t, clientset, st, false)
+	gc.collect(ctx)
+
+	cms, err := clientset.CoreV1().ConfigMaps(testNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, cms.Items, "all %d orphaned configmaps should be deleted", n)
 }
 
 func TestGC_SkipsStoreConfigMaps(t *testing.T) {

--- a/internal/mcp/tools_share_links.go
+++ b/internal/mcp/tools_share_links.go
@@ -55,7 +55,7 @@ func registerListShareLinksTool(server *mcp.Server, orch *orchestrator.Orchestra
 		Name:        "list_share_links",
 		Description: "List all share links for an artifact. Only the artifact owner or admin can see these.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, input listShareLinksInput) (*mcp.CallToolResult, *listShareLinksOutput, error) {
-		links, err := orch.ListShareLinks(ctx, input.ArtifactID)
+		links, err := orch.ListShareLinks(ctx, input.ArtifactID, 0, 0)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/mcp/tools_users.go
+++ b/internal/mcp/tools_users.go
@@ -29,7 +29,7 @@ func registerListUsersTool(server *mcp.Server, userStore store.UserStore) {
 		if !vibedauth.IsAdmin(ctx) {
 			return nil, nil, fmt.Errorf("admin access required")
 		}
-		users, err := userStore.ListUsers(ctx, input.DepartmentID)
+		users, err := userStore.ListUsers(ctx, input.DepartmentID, 0, 0)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -76,7 +76,7 @@ func registerListDepartmentsTool(server *mcp.Server, userStore store.UserStore) 
 		if !vibedauth.IsAdmin(ctx) {
 			return nil, nil, fmt.Errorf("admin access required")
 		}
-		depts, err := userStore.ListDepartments(ctx)
+		depts, err := userStore.ListDepartments(ctx, 0, 0)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -18,6 +18,33 @@ import (
 
 const maxRateLimitClients = 50000
 
+// Fallback write-verb limits when RateLimitConfig leaves them unset (<=0), so a
+// partial config can't accidentally leave the deploy path unlimited.
+const (
+	defaultWriteRPS   = 1.0
+	defaultWriteBurst = 5
+)
+
+// limiterClass selects which per-client token-bucket pool a request draws from.
+type limiterClass int
+
+const (
+	classGeneral limiterClass = iota // reads / general API traffic
+	classToken                       // per-share-link password attempts
+	classWrite                       // expensive mutating verbs (deploy/create/update/delete)
+)
+
+// isWriteVerb reports whether method is a mutating HTTP verb that should draw
+// from the stricter write budget.
+func isWriteVerb(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
 // rateLimitEvictSample bounds the work of a single eviction: we look at this
 // many entries and drop the least-recently-seen among them. Redis uses a
 // similar sampled-LRU with a sample of ~5-10; 16 tightens the approximation
@@ -56,52 +83,69 @@ func evictOldestSampled(cmap map[string]*client) {
 // Only /api/ and /mcp paths are rate-limited; health, metrics, and static are skipped.
 // The ctx parameter controls the cleanup goroutine lifetime.
 func RateLimiter(ctx context.Context, cfg config.RateLimitConfig, m *metrics.Metrics) func(http.Handler) http.Handler {
+	// Write verbs get their own tighter budget; fall back to a safe default when
+	// unset so a partial config can't accidentally leave them unlimited.
+	writeRPS := cfg.WriteRequestsPerSecond
+	if writeRPS <= 0 {
+		writeRPS = defaultWriteRPS
+	}
+	writeBurst := cfg.WriteBurst
+	if writeBurst <= 0 {
+		writeBurst = defaultWriteBurst
+	}
+
 	var mu sync.RWMutex
 	clients := make(map[string]*client)
 
 	var tokenMu sync.RWMutex
 	tokenClients := make(map[string]*client)
 
+	var writeMu sync.RWMutex
+	writeClients := make(map[string]*client)
+
 	// Periodically clean up stale entries; stops when ctx is cancelled.
 	go func() {
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
+		sweep := func(mu *sync.RWMutex, cmap map[string]*client) {
+			mu.Lock()
+			defer mu.Unlock()
+			for key, c := range cmap {
+				if time.Since(c.lastSeen) > 10*time.Minute {
+					delete(cmap, key)
+				}
+			}
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				mu.Lock()
-				for key, c := range clients {
-					if time.Since(c.lastSeen) > 10*time.Minute {
-						delete(clients, key)
-					}
-				}
-				mu.Unlock()
-
-				tokenMu.Lock()
-				for key, c := range tokenClients {
-					if time.Since(c.lastSeen) > 10*time.Minute {
-						delete(tokenClients, key)
-					}
-				}
-				tokenMu.Unlock()
+				sweep(&mu, clients)
+				sweep(&tokenMu, tokenClients)
+				sweep(&writeMu, writeClients)
 			}
 		}
 	}()
 
-	getLimiter := func(key string, isToken bool) *rate.Limiter {
+	getLimiter := func(key string, class limiterClass) *rate.Limiter {
 		var m *sync.RWMutex
 		var cmap map[string]*client
 		var r rate.Limit
 		var b int
 
-		if isToken {
+		switch class {
+		case classToken:
 			m = &tokenMu
 			cmap = tokenClients
 			r = rate.Every(time.Minute / 5) // 5 per minute
 			b = 5
-		} else {
+		case classWrite:
+			m = &writeMu
+			cmap = writeClients
+			r = rate.Limit(writeRPS)
+			b = writeBurst
+		default: // classGeneral
 			m = &mu
 			cmap = clients
 			r = rate.Limit(cfg.RequestsPerSecond)
@@ -146,8 +190,10 @@ func RateLimiter(ctx context.Context, cfg config.RateLimitConfig, m *metrics.Met
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			path := r.URL.Path
 
-			// Only rate-limit API and MCP paths
-			if !strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/mcp") {
+			// Rate-limit the API surfaces (REST /api, deploy/read /v1, and MCP);
+			// health, metrics, and static assets are skipped. /v1/* — including
+			// the expensive deploy path — was previously unthrottled (#50).
+			if !strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/mcp") && !strings.HasPrefix(path, "/v1/") {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -156,7 +202,7 @@ func RateLimiter(ctx context.Context, cfg config.RateLimitConfig, m *metrics.Met
 			if r.Method == http.MethodPost && strings.HasPrefix(path, "/api/share/") {
 				token := strings.TrimPrefix(path, "/api/share/")
 				if token != "" {
-					if !getLimiter(token, true).Allow() {
+					if !getLimiter(token, classToken).Allow() {
 						m.RateLimitedTotal.WithLabelValues("token").Inc()
 						w.Header().Set("Retry-After", "12")
 						http.Error(w, "rate limit exceeded for this share link", http.StatusTooManyRequests)
@@ -176,7 +222,17 @@ func RateLimiter(ctx context.Context, cfg config.RateLimitConfig, m *metrics.Met
 				}
 			}
 
-			if !getLimiter(key, false).Allow() {
+			// Expensive mutating REST verbs (deploy/create/update/delete on /v1
+			// or /api) draw from a stricter per-client budget so one user can't
+			// flood the deploy path. MCP stays on the general limiter — it's
+			// JSON-RPC over POST, so the HTTP method doesn't distinguish reads
+			// from writes there.
+			class := classGeneral
+			if isWriteVerb(r.Method) && (strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/api/")) {
+				class = classWrite
+			}
+
+			if !getLimiter(key, class).Allow() {
 				m.RateLimitedTotal.WithLabelValues(clientType).Inc()
 				w.Header().Set("Retry-After", "1")
 				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -18,9 +18,37 @@ import (
 
 const maxRateLimitClients = 50000
 
+// rateLimitEvictSample bounds the work of a single eviction: we look at this
+// many entries and drop the least-recently-seen among them. Redis uses a
+// similar sampled-LRU with a sample of ~5-10; 16 tightens the approximation
+// while keeping eviction O(1) with respect to map size.
+const rateLimitEvictSample = 16
+
 type client struct {
 	limiter  *rate.Limiter
 	lastSeen time.Time
+}
+
+// evictOldestSampled deletes the least-recently-seen of up to
+// rateLimitEvictSample entries (all of them when the map is smaller than the
+// sample). Cost is bounded by the sample size, not len(cmap). Caller holds the
+// write lock. A no-op on an empty map.
+func evictOldestSampled(cmap map[string]*client) {
+	var oldestKey string
+	var oldestTime time.Time
+	seen := 0
+	for k, c := range cmap {
+		if oldestKey == "" || c.lastSeen.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = c.lastSeen
+		}
+		if seen++; seen >= rateLimitEvictSample {
+			break
+		}
+	}
+	if oldestKey != "" {
+		delete(cmap, oldestKey)
+	}
 }
 
 // RateLimiter returns HTTP middleware that rate-limits requests per client.
@@ -99,17 +127,14 @@ func RateLimiter(ctx context.Context, cfg config.RateLimitConfig, m *metrics.Met
 			return c.limiter
 		}
 
-		// Evict oldest entry if at capacity
+		// Evict one entry if at capacity. We sample a bounded number of entries
+		// and drop the oldest of the sample (approximate LRU) rather than scanning
+		// the whole map: a full O(n) scan under the write lock let an attacker
+		// rotating keys thrash eviction and degrade throughput for every client
+		// (issue #62). Go randomizes map iteration, so a small sample is a
+		// good-enough oldest-estimate for a cache this size.
 		if len(cmap) >= maxRateLimitClients {
-			var oldestKey string
-			var oldestTime time.Time
-			for k, c := range cmap {
-				if oldestKey == "" || c.lastSeen.Before(oldestTime) {
-					oldestKey = k
-					oldestTime = c.lastSeen
-				}
-			}
-			delete(cmap, oldestKey)
+			evictOldestSampled(cmap)
 		}
 
 		limiter := rate.NewLimiter(r, b)

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,9 +1,74 @@
 package middleware
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/vibed-project/vibeD/internal/config"
+	"github.com/vibed-project/vibeD/internal/metrics"
 )
+
+// serveN sends n requests (method, path) through the rate-limit middleware and
+// returns how many were allowed (200) vs limited (429).
+func serveN(t *testing.T, mw func(http.Handler) http.Handler, method, path string, n int) (allowed, limited int) {
+	t.Helper()
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	for i := 0; i < n; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(method, path, nil)
+		req.RemoteAddr = "203.0.113.7:5555" // stable IP key
+		h.ServeHTTP(rec, req)
+		switch rec.Code {
+		case http.StatusOK:
+			allowed++
+		case http.StatusTooManyRequests:
+			limited++
+		}
+	}
+	return allowed, limited
+}
+
+// TestRateLimitCoversV1AndWriteClass locks in issue #50: /v1/* is rate-limited
+// at all, and mutating verbs draw from the stricter write budget (so a burst of
+// deploys is cut off well before a burst of reads would be).
+func TestRateLimitCoversV1AndWriteClass(t *testing.T) {
+	m := metrics.New()
+	cfg := config.RateLimitConfig{
+		Enabled:                true,
+		RequestsPerSecond:      1,
+		Burst:                  100, // generous read budget
+		WriteRequestsPerSecond: 1,
+		WriteBurst:             3, // tight write budget
+	}
+	mw := RateLimiter(context.Background(), cfg, m)
+
+	// /v1 is now covered: writes beyond the write burst are limited.
+	allowed, limited := serveN(t, mw, http.MethodPost, "/v1/deploy", 10)
+	if limited == 0 {
+		t.Fatalf("POST /v1/deploy should be rate-limited past the write burst; allowed=%d limited=%d", allowed, limited)
+	}
+	if allowed > cfg.WriteBurst {
+		t.Errorf("allowed %d writes, want <= writeBurst %d", allowed, cfg.WriteBurst)
+	}
+
+	// Reads on /v1 draw from the generous general budget — the earlier write
+	// throttling must not have consumed it.
+	if a, l := serveN(t, mw, http.MethodGet, "/v1/apps", 50); a != 50 || l != 0 {
+		t.Errorf("GET /v1/apps under general budget: allowed=%d limited=%d, want 50/0", a, l)
+	}
+}
+
+// TestRateLimitSkipsNonAPIPaths confirms health/static paths are still exempt.
+func TestRateLimitSkipsNonAPIPaths(t *testing.T) {
+	m := metrics.New()
+	mw := RateLimiter(context.Background(), config.RateLimitConfig{Enabled: true, RequestsPerSecond: 1, Burst: 1}, m)
+	if a, l := serveN(t, mw, http.MethodGet, "/healthz", 20); a != 20 || l != 0 {
+		t.Errorf("/healthz should be exempt: allowed=%d limited=%d, want 20/0", a, l)
+	}
+}
 
 // TestEvictOldestSampled covers the bounded-sample eviction added for issue #62.
 func TestEvictOldestSampled(t *testing.T) {

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEvictOldestSampled covers the bounded-sample eviction added for issue #62.
+func TestEvictOldestSampled(t *testing.T) {
+	now := time.Now()
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		cmap := map[string]*client{}
+		evictOldestSampled(cmap) // must not panic
+		if len(cmap) != 0 {
+			t.Fatalf("len = %d, want 0", len(cmap))
+		}
+	})
+
+	t.Run("evicts the true oldest when map fits in the sample", func(t *testing.T) {
+		// With <= rateLimitEvictSample entries, every entry is scanned, so the
+		// least-recently-seen one is deterministically evicted.
+		cmap := map[string]*client{
+			"new":    {lastSeen: now},
+			"oldest": {lastSeen: now.Add(-1 * time.Hour)},
+			"mid":    {lastSeen: now.Add(-30 * time.Minute)},
+		}
+		evictOldestSampled(cmap)
+		if _, ok := cmap["oldest"]; ok {
+			t.Fatalf("oldest entry should have been evicted; map=%v", keys(cmap))
+		}
+		if len(cmap) != 2 {
+			t.Fatalf("len = %d, want 2", len(cmap))
+		}
+	})
+
+	t.Run("evicts exactly one entry on a large map", func(t *testing.T) {
+		cmap := make(map[string]*client, rateLimitEvictSample*4)
+		for i := 0; i < rateLimitEvictSample*4; i++ {
+			cmap[string(rune('a'+i%26))+time.Duration(i).String()] = &client{lastSeen: now.Add(-time.Duration(i) * time.Second)}
+		}
+		before := len(cmap)
+		evictOldestSampled(cmap)
+		if len(cmap) != before-1 {
+			t.Fatalf("len = %d, want %d (exactly one evicted)", len(cmap), before-1)
+		}
+	})
+}
+
+func keys(m map[string]*client) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1360,8 +1360,9 @@ func (o *Orchestrator) CreateShareLink(ctx context.Context, artifactID, password
 	return link, nil
 }
 
-// ListShareLinks returns all share links for an artifact.
-func (o *Orchestrator) ListShareLinks(ctx context.Context, artifactID string) ([]api.ShareLink, error) {
+// ListShareLinks returns an artifact's share links. limit<=0 returns all;
+// limit>0 pages with offset.
+func (o *Orchestrator) ListShareLinks(ctx context.Context, artifactID string, limit, offset int) ([]api.ShareLink, error) {
 	if o.shareLinkStore == nil {
 		return nil, fmt.Errorf("share links require SQLite store backend")
 	}
@@ -1373,7 +1374,7 @@ func (o *Orchestrator) ListShareLinks(ctx context.Context, artifactID string) ([
 	if err := o.checkOwnership(ctx, artifact); err != nil {
 		return nil, err
 	}
-	links, err := o.shareLinkStore.ListShareLinks(ctx, artifactID)
+	links, err := o.shareLinkStore.ListShareLinks(ctx, artifactID, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/quota/enforcer.go
+++ b/internal/quota/enforcer.go
@@ -104,7 +104,7 @@ func (e *Enforcer) Authorize(ctx context.Context, t tenant.Tenant, owner string,
 	}
 
 	if max := e.cfg.MaxAppsPerOwner; max > 0 {
-		n, cerr := e.count(ctx, ns, vibedv1.LabelOwner, vibedv1.SanitizeLabel(owner))
+		n, cerr := e.countByOwner(ctx, ns, owner)
 		if cerr != nil {
 			return department, cerr
 		}
@@ -136,6 +136,31 @@ func (e *Enforcer) deptCeiling(dept string) int {
 		return v
 	}
 	return e.cfg.MaxAppsPerDepartment
+}
+
+// countByOwner counts live VibedApps in namespace owned by exactly `owner`.
+//
+// The vibed.dev/owner label is a sanitized, ≤63-char (lossy) mirror of
+// spec.owner, so distinct identities can collide onto one label value — e.g.
+// "alice@corp" and "alice_corp", or two OIDC subjects sharing a 63-char prefix.
+// Counting by the label alone would let colliding owners share a quota bucket
+// (a cross-account DoS plus a partial quota bypass, issue #66). We therefore use
+// the label only as a coarse server-side pre-filter — a collision can only add
+// extra candidates, never drop a genuine match — and then count the apps whose
+// exact spec.owner equals owner, which is the authoritative identity.
+func (e *Enforcer) countByOwner(ctx context.Context, namespace, owner string) (int, error) {
+	var list vibedv1.VibedAppList
+	if err := e.client.List(ctx, &list, client.InNamespace(namespace),
+		client.MatchingLabels{vibedv1.LabelOwner: vibedv1.SanitizeLabel(owner)}); err != nil {
+		return 0, fmt.Errorf("count apps by owner %q: %w", owner, err)
+	}
+	n := 0
+	for i := range list.Items {
+		if list.Items[i].Spec.Owner == owner {
+			n++
+		}
+	}
+	return n, nil
 }
 
 // count returns the number of live VibedApps in namespace carrying the given

--- a/internal/quota/enforcer.go
+++ b/internal/quota/enforcer.go
@@ -8,6 +8,8 @@ package quota
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -18,6 +20,12 @@ import (
 	"github.com/vibed-project/vibeD/pkg/api"
 	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
 )
+
+// defaultReservationTTL backstops a reservation whose release is never called
+// (a caller bug): normal deploys release promptly once the app is List-visible,
+// so this only bounds the blast radius of a leak. Generous enough to outlast a
+// slow tarball upload window between the count check and the Create.
+const defaultReservationTTL = 2 * time.Minute
 
 // UserResolver is the slice of the user store the enforcer needs to map an
 // owner to a department. store.UserStore satisfies it.
@@ -67,11 +75,90 @@ type Enforcer struct {
 	users     UserResolver
 	namespace string
 	cfg       config.QuotasConfig
+
+	// reservations bridge the TOCTOU window between the count check and the new
+	// app becoming List-visible, so concurrent deploys can't all read a
+	// below-ceiling count and overshoot the ceiling (#75). Keyed by scope, each
+	// entry is an in-flight deploy's expiry (a TTL leak backstop).
+	reservationTTL time.Duration
+	mu             sync.Mutex
+	nextResID      uint64
+	reservations   map[resKey]map[uint64]int64 // scope -> reservationID -> expiry unixNano
 }
+
+// resKey scopes reservations the same way the ceilings are scoped: per
+// namespace + scope (tenant|owner|department) + identity.
+type resKey struct{ ns, scope, id string }
 
 // NewEnforcer builds an Enforcer over the apps namespace.
 func NewEnforcer(c client.Client, users UserResolver, namespace string, cfg config.QuotasConfig) *Enforcer {
-	return &Enforcer{client: c, users: users, namespace: namespace, cfg: cfg}
+	return &Enforcer{
+		client:         c,
+		users:          users,
+		namespace:      namespace,
+		cfg:            cfg,
+		reservationTTL: defaultReservationTTL,
+		reservations:   map[resKey]map[uint64]int64{},
+	}
+}
+
+// tryReserve atomically checks listed+reserved < max for key and, when there is
+// room, records a reservation and returns its release with ok=true. Otherwise
+// ok=false and the current total (listed + live reservations). The List that
+// produced `listed` happens outside e.mu (it's remote I/O); reservations account
+// for concurrent in-flight deploys not yet reflected in listed. The returned
+// release is idempotent.
+func (e *Enforcer) tryReserve(key resKey, listed, max int, now time.Time) (release func(), total int, ok bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	total = listed + e.reservedCountLocked(key, now)
+	if total >= max {
+		return func() {}, total, false
+	}
+
+	e.nextResID++
+	id := e.nextResID
+	m := e.reservations[key]
+	if m == nil {
+		m = map[uint64]int64{}
+		e.reservations[key] = m
+	}
+	m[id] = now.Add(e.reservationTTL).UnixNano()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			e.mu.Lock()
+			defer e.mu.Unlock()
+			if mm := e.reservations[key]; mm != nil {
+				delete(mm, id)
+				if len(mm) == 0 {
+					delete(e.reservations, key)
+				}
+			}
+		})
+	}, total + 1, true
+}
+
+// reservedCountLocked returns the number of unexpired reservations for key,
+// pruning expired ones. Caller holds e.mu.
+func (e *Enforcer) reservedCountLocked(key resKey, now time.Time) int {
+	m := e.reservations[key]
+	if m == nil {
+		return 0
+	}
+	nowNano := now.UnixNano()
+	for id, exp := range m {
+		if exp <= nowNano {
+			delete(m, id)
+		}
+	}
+	if len(m) == 0 {
+		delete(e.reservations, key)
+		return 0
+	}
+	return len(m)
 }
 
 // Authorize resolves owner's department (returned so the caller can label the
@@ -80,7 +167,16 @@ func NewEnforcer(c client.Client, users UserResolver, namespace string, cfg conf
 // tenant's namespace (falling back to the enforcer's default namespace when the
 // tenant leaves it empty), so ceilings are enforced per tenant. Redeploys
 // (isNew=false) skip the ceiling checks but still return the department.
-func (e *Enforcer) Authorize(ctx context.Context, t tenant.Tenant, owner string, isNew bool) (department string, err error) {
+//
+// On success it returns a non-nil release the caller MUST invoke once the new
+// app is durably created (List-visible) or the deploy has failed. The release
+// drops the reservation this call took against each ceiling; holding it across
+// the count-check→Create window is what stops concurrent deploys from all
+// reading a below-ceiling count and overshooting (#75). release is always
+// non-nil (a no-op on the redeploy / rejection paths) so callers can defer it
+// unconditionally.
+func (e *Enforcer) Authorize(ctx context.Context, t tenant.Tenant, owner string, isNew bool) (department string, release func(), err error) {
+	noop := func() {}
 	ns := t.Namespace
 	if ns == "" {
 		ns = e.namespace
@@ -88,46 +184,66 @@ func (e *Enforcer) Authorize(ctx context.Context, t tenant.Tenant, owner string,
 
 	department = e.departmentFor(ctx, owner)
 	if !isNew {
-		return department, nil
+		return department, noop, nil
+	}
+
+	now := time.Now()
+	var releases []func()
+	releaseAll := func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
 	}
 
 	// Per-tenant total ceiling (all apps in the tenant namespace).
 	if max := t.Limits.MaxApps; max > 0 {
 		n, cerr := e.countAll(ctx, ns)
 		if cerr != nil {
-			return department, cerr
+			releaseAll()
+			return department, noop, cerr
 		}
-		if n >= max {
+		rel, total, ok := e.tryReserve(resKey{ns, "tenant", t.ID}, n, max, now)
+		if !ok {
+			releaseAll()
 			rejections.WithLabelValues("tenant").Inc()
-			return department, &ExceededError{Scope: "tenant", Tenant: t.ID, Limit: max, Current: n}
+			return department, noop, &ExceededError{Scope: "tenant", Tenant: t.ID, Limit: max, Current: total}
 		}
+		releases = append(releases, rel)
 	}
 
 	if max := e.cfg.MaxAppsPerOwner; max > 0 {
 		n, cerr := e.countByOwner(ctx, ns, owner)
 		if cerr != nil {
-			return department, cerr
+			releaseAll()
+			return department, noop, cerr
 		}
-		if n >= max {
+		rel, total, ok := e.tryReserve(resKey{ns, "owner", owner}, n, max, now)
+		if !ok {
+			releaseAll()
 			rejections.WithLabelValues("owner").Inc()
-			return department, &ExceededError{Scope: "owner", Owner: owner, Limit: max, Current: n}
+			return department, noop, &ExceededError{Scope: "owner", Owner: owner, Limit: max, Current: total}
 		}
+		releases = append(releases, rel)
 	}
 
 	if department != "" {
 		if max := e.deptCeiling(department); max > 0 {
 			n, cerr := e.count(ctx, ns, vibedv1.LabelDepartment, vibedv1.SanitizeLabel(department))
 			if cerr != nil {
-				return department, cerr
+				releaseAll()
+				return department, noop, cerr
 			}
-			if n >= max {
+			rel, total, ok := e.tryReserve(resKey{ns, "department", department}, n, max, now)
+			if !ok {
+				releaseAll()
 				rejections.WithLabelValues("department").Inc()
-				return department, &ExceededError{Scope: "department", Department: department, Limit: max, Current: n}
+				return department, noop, &ExceededError{Scope: "department", Department: department, Limit: max, Current: total}
 			}
+			releases = append(releases, rel)
 		}
 	}
 
-	return department, nil
+	return department, releaseAll, nil
 }
 
 // deptCeiling returns the per-department override if set, else the global cap.

--- a/internal/quota/enforcer_test.go
+++ b/internal/quota/enforcer_test.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,12 +65,12 @@ func TestPerOwnerCeiling(t *testing.T) {
 	c := newClient(t, app("a", "alice", ""), app("b", "alice", ""))
 	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: 2})
 
-	_, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "alice", true)
+	_, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "alice", true)
 	var qe *ExceededError
 	if !errors.As(err, &qe) || qe.Scope != "owner" {
 		t.Fatalf("alice at limit: want owner ExceededError, got %v", err)
 	}
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "bob", true); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "bob", true); err != nil {
 		t.Fatalf("bob (0 apps) should be allowed: %v", err)
 	}
 }
@@ -89,15 +90,85 @@ func TestPerOwnerCeilingNoLabelCollision(t *testing.T) {
 	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: 2})
 
 	// alice@corp is at 2/2 -> rejected.
-	_, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, a, true)
+	_, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, a, true)
 	var qe *ExceededError
 	if !errors.As(err, &qe) || qe.Scope != "owner" || qe.Current != 2 {
 		t.Fatalf("%s at limit: want owner ExceededError current=2, got %v", a, err)
 	}
 
 	// alice_corp owns 0 apps despite the label collision -> must be allowed.
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, b, true); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, b, true); err != nil {
 		t.Fatalf("%s (0 apps, colliding label) should be allowed, got %v", b, err)
+	}
+}
+
+// TestPerOwnerCeilingNoOvershootUnderConcurrency is the #75 regression: many
+// deploys for the same owner authorize concurrently against a fresh (0-app)
+// store, so every call's List returns 0. Without the reservation ledger they
+// would all read "below ceiling" and overshoot; with it, exactly `limit` are
+// authorized because each reservation is visible to the next check.
+func TestPerOwnerCeilingNoOvershootUnderConcurrency(t *testing.T) {
+	const limit = 3
+	const goroutines = 20
+	c := newClient(t) // empty: List always returns 0 during the race
+	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: limit})
+
+	var wg sync.WaitGroup
+	oks := make([]bool, goroutines)
+	releases := make([]func(), goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, release, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "alice", true)
+			releases[i] = release
+			oks[i] = err == nil
+		}(i)
+	}
+	wg.Wait()
+
+	authorized := 0
+	for _, ok := range oks {
+		if ok {
+			authorized++
+		}
+	}
+	if authorized != limit {
+		t.Fatalf("concurrent deploys authorized = %d, want exactly %d (reservations must bound it to the ceiling)", authorized, limit)
+	}
+
+	// Releasing every reservation frees the slots again (nothing was created).
+	for _, rel := range releases {
+		if rel != nil {
+			rel()
+		}
+	}
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "alice", true); err != nil {
+		t.Fatalf("after releasing all reservations a new deploy must be allowed, got %v", err)
+	}
+}
+
+// TestReservationReleasedOnRejection makes sure a deploy that clears the owner
+// ceiling but trips a later (department) ceiling doesn't leak the owner-scope
+// reservation it already took.
+func TestReservationReleasedOnRejection(t *testing.T) {
+	users := &fakeUsers{deptOf: map[string]string{"carol": "platform"}}
+	// Owner ceiling 5 (room), department ceiling 1 with one app already present.
+	c := newClient(t, app("existing", "someoneelse", "platform"))
+	e := NewEnforcer(c, users, ns, config.QuotasConfig{
+		Enabled: true, MaxAppsPerOwner: 5,
+		PerDepartment: map[string]int{"platform": 1},
+	})
+
+	// carol trips the department ceiling → rejected, but her owner reservation
+	// must be released. Do it a few times; a leak would accumulate and eventually
+	// (wrongly) trip the owner ceiling of 5.
+	for i := 0; i < 8; i++ {
+		_, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "carol", true)
+		var qe *ExceededError
+		if !errors.As(err, &qe) || qe.Scope != "department" {
+			t.Fatalf("iter %d: want department ExceededError, got %v", i, err)
+		}
 	}
 }
 
@@ -105,7 +176,7 @@ func TestRedeploySkipsCeiling(t *testing.T) {
 	c := newClient(t, app("a", "alice", ""), app("b", "alice", ""))
 	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: 2})
 
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "alice", false); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "alice", false); err != nil {
 		t.Fatalf("redeploy (isNew=false) must skip the ceiling: %v", err)
 	}
 }
@@ -115,7 +186,7 @@ func TestPerDepartmentCeiling(t *testing.T) {
 	users := &fakeUsers{deptOf: map[string]string{"carol": "platform"}}
 	e := NewEnforcer(c, users, ns, config.QuotasConfig{Enabled: true, MaxAppsPerDepartment: 2})
 
-	dept, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "carol", true)
+	dept, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "carol", true)
 	if dept != "platform" {
 		t.Fatalf("department resolution = %q, want platform", dept)
 	}
@@ -131,7 +202,7 @@ func TestPerDepartmentOverride(t *testing.T) {
 	cfg := config.QuotasConfig{Enabled: true, MaxAppsPerDepartment: 2, PerDepartment: map[string]int{"platform": 5}}
 	e := NewEnforcer(c, users, ns, cfg)
 
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "carol", true); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "carol", true); err != nil {
 		t.Fatalf("override should raise platform cap to 5: %v", err)
 	}
 }
@@ -149,13 +220,13 @@ func TestTenantCeiling(t *testing.T) {
 	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true})
 
 	// A tenant total cap of 2 with 2 apps already in the namespace -> rejected.
-	_, err := e.Authorize(context.Background(), tenant.Tenant{ID: "t1", Namespace: ns, Limits: tenant.Limits{MaxApps: 2}}, "carol", true)
+	_, _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "t1", Namespace: ns, Limits: tenant.Limits{MaxApps: 2}}, "carol", true)
 	var qe *ExceededError
 	if !errors.As(err, &qe) || qe.Scope != "tenant" {
 		t.Fatalf("tenant at 2/2: want tenant ExceededError, got %v", err)
 	}
 	// A different, empty tenant namespace is allowed under the same cap.
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "t2", Namespace: "other-ns", Limits: tenant.Limits{MaxApps: 2}}, "carol", true); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "t2", Namespace: "other-ns", Limits: tenant.Limits{MaxApps: 2}}, "carol", true); err != nil {
 		t.Fatalf("an empty tenant should be allowed: %v", err)
 	}
 }
@@ -166,10 +237,10 @@ func TestCeilingsAreTenantNamespaceScoped(t *testing.T) {
 	c := newClient(t, appNs("tenant-a", "a", "alice"), appNs("tenant-a", "b", "alice"))
 	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: 2})
 
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "a", Namespace: "tenant-a"}, "alice", true); err == nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "a", Namespace: "tenant-a"}, "alice", true); err == nil {
 		t.Fatal("alice should be at her per-owner cap within tenant-a")
 	}
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "b", Namespace: "tenant-b"}, "alice", true); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{ID: "b", Namespace: "tenant-b"}, "alice", true); err != nil {
 		t.Fatalf("alice's tenant-a apps must not count in tenant-b: %v", err)
 	}
 }
@@ -180,7 +251,7 @@ func TestNoResolverSkipsDepartmentGate(t *testing.T) {
 
 	// No user resolver -> department unknown -> only the (unset) per-owner cap
 	// applies, so the deploy is allowed.
-	if _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "bob", true); err != nil {
+	if _, _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, "bob", true); err != nil {
 		t.Fatalf("missing resolver should skip the department gate: %v", err)
 	}
 }

--- a/internal/quota/enforcer_test.go
+++ b/internal/quota/enforcer_test.go
@@ -74,6 +74,33 @@ func TestPerOwnerCeiling(t *testing.T) {
 	}
 }
 
+// TestPerOwnerCeilingNoLabelCollision guards issue #66: two owners whose
+// identities sanitize to the SAME vibed.dev/owner label ("alice@corp" and
+// "alice_corp" both -> "alice_corp") must not share a quota bucket. alice@corp
+// is at its limit; alice_corp (0 apps of its own) must still be allowed, and
+// alice@corp must be counted against only its own apps.
+func TestPerOwnerCeilingNoLabelCollision(t *testing.T) {
+	const a, b = "alice@corp", "alice_corp"
+	if vibedv1.SanitizeLabel(a) != vibedv1.SanitizeLabel(b) {
+		t.Fatalf("test premise broken: %q and %q must sanitize to the same label", a, b)
+	}
+	// Two apps owned by alice@corp, zero owned by alice_corp.
+	c := newClient(t, app("x", a, ""), app("y", a, ""))
+	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: 2})
+
+	// alice@corp is at 2/2 -> rejected.
+	_, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, a, true)
+	var qe *ExceededError
+	if !errors.As(err, &qe) || qe.Scope != "owner" || qe.Current != 2 {
+		t.Fatalf("%s at limit: want owner ExceededError current=2, got %v", a, err)
+	}
+
+	// alice_corp owns 0 apps despite the label collision -> must be allowed.
+	if _, err := e.Authorize(context.Background(), tenant.Tenant{Namespace: ns}, b, true); err != nil {
+		t.Fatalf("%s (0 apps, colliding label) should be allowed, got %v", b, err)
+	}
+}
+
 func TestRedeploySkipsCeiling(t *testing.T) {
 	c := newClient(t, app("a", "alice", ""), app("b", "alice", ""))
 	e := NewEnforcer(c, nil, ns, config.QuotasConfig{Enabled: true, MaxAppsPerOwner: 2})

--- a/internal/runneragent/ringbuffer.go
+++ b/internal/runneragent/ringbuffer.go
@@ -9,10 +9,17 @@ import (
 // io.Writer so it can be wired directly into a process's stdout/stderr, and
 // keeps only the most recent `capacity` complete lines. It is safe for
 // concurrent use.
+//
+// Storage is a true circular buffer: `buf` is a fixed slice of len==capacity,
+// `start` indexes the oldest line and `count` the number of live lines. This
+// makes eviction O(1) (overwrite one slot, advance start) instead of the O(n)
+// shift a growing slice would need per line on a high-volume stream.
 type ringBuffer struct {
 	mu       sync.Mutex
 	capacity int
-	lines    []string // most recent at the end
+	buf      []string // circular; len == capacity, oldest at start
+	start    int      // index of the oldest live line
+	count    int      // number of live lines (0..capacity)
 	partial  []byte   // bytes since the last newline
 }
 
@@ -20,7 +27,7 @@ func newRingBuffer(capacity int) *ringBuffer {
 	if capacity < 1 {
 		capacity = 1
 	}
-	return &ringBuffer{capacity: capacity}
+	return &ringBuffer{capacity: capacity, buf: make([]string, capacity)}
 }
 
 // Write splits incoming bytes on newlines, appending complete lines to the
@@ -46,28 +53,56 @@ func (r *ringBuffer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// appendLine adds a line, evicting the oldest if at capacity. Caller holds mu.
+// appendLine adds a line, evicting the oldest in O(1) when at capacity. Caller
+// holds mu.
 func (r *ringBuffer) appendLine(line string) {
-	if len(r.lines) >= r.capacity {
-		// Drop the oldest. Copy to keep the backing array bounded.
-		r.lines = append(r.lines[:0], r.lines[1:]...)
+	end := (r.start + r.count) % r.capacity
+	r.buf[end] = line
+	if r.count < r.capacity {
+		r.count++
+		return
 	}
-	r.lines = append(r.lines, line)
+	// Full: the write above landed on the oldest slot (end == start), so that
+	// slot is now the newest line; advance start to the next-oldest.
+	r.start = (r.start + 1) % r.capacity
 }
 
 // snapshot returns up to the last n captured lines (all of them when n <= 0),
-// including any trailing partial line.
+// including any trailing partial line. It copies only the tail it returns, not
+// the whole buffer.
 func (r *ringBuffer) snapshot(n int) []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	out := make([]string, len(r.lines))
-	copy(out, r.lines)
-	if len(r.partial) > 0 {
-		out = append(out, string(r.partial))
+	hasPartial := len(r.partial) > 0
+	total := r.count
+	if hasPartial {
+		total++
 	}
-	if n > 0 && len(out) > n {
-		out = out[len(out)-n:]
+	take := total
+	if n > 0 && n < take {
+		take = n
+	}
+	if take <= 0 {
+		return []string{}
+	}
+
+	// The logical order is [oldest line ... newest line, partial?]; we return
+	// the last `take` of that sequence. When a partial is present it is the very
+	// last element, so it consumes one slot and the rest come from committed
+	// lines.
+	commitTake := take
+	if hasPartial {
+		commitTake = take - 1
+	}
+	skip := r.count - commitTake // number of oldest committed lines to drop
+
+	out := make([]string, 0, take)
+	for i := 0; i < commitTake; i++ {
+		out = append(out, r.buf[(r.start+skip+i)%r.capacity])
+	}
+	if hasPartial {
+		out = append(out, string(r.partial))
 	}
 	return out
 }
@@ -76,6 +111,12 @@ func (r *ringBuffer) snapshot(n int) []string {
 func (r *ringBuffer) reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.lines = r.lines[:0]
+	// Drop references so evicted log lines can be GC'd rather than pinned by the
+	// backing array until overwritten.
+	for i := range r.buf {
+		r.buf[i] = ""
+	}
+	r.start = 0
+	r.count = 0
 	r.partial = r.partial[:0]
 }

--- a/internal/runneragent/ringbuffer_test.go
+++ b/internal/runneragent/ringbuffer_test.go
@@ -2,6 +2,7 @@ package runneragent
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -31,6 +32,25 @@ func TestRingBufferSnapshotN(t *testing.T) {
 	r.Write([]byte("1\n2\n3\n4\n5\n"))
 	if got := r.snapshot(2); !reflect.DeepEqual(got, []string{"4", "5"}) {
 		t.Fatalf("snapshot(2) = %v, want [4 5]", got)
+	}
+}
+
+// TestRingBufferWrapAround exercises the circular buffer well past capacity
+// (issue #79): after many evictions it must still hold exactly the last
+// `capacity` lines, in order, regardless of how many times start wrapped.
+func TestRingBufferWrapAround(t *testing.T) {
+	r := newRingBuffer(3)
+	for i := 0; i < 100; i++ {
+		r.Write([]byte(strconv.Itoa(i) + "\n"))
+	}
+	got := r.snapshot(0)
+	want := []string{"97", "98", "99"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("after 100 writes snapshot = %v, want %v", got, want)
+	}
+	// snapshot(n) larger than the live count returns everything, no panic.
+	if got := r.snapshot(10); !reflect.DeepEqual(got, want) {
+		t.Fatalf("snapshot(10) = %v, want %v", got, want)
 	}
 }
 

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -26,6 +26,13 @@ const maxConfigMapBytes = 900 * 1024
 // Each artifact is stored as a JSON entry keyed by its ID.
 // Versions are stored in a separate ConfigMap named "{name}-versions".
 //
+// Scale: all artifacts share one ConfigMap, so every write is a read-modify-write
+// of the whole object and the aggregate is bounded by etcd's ~1MB object ceiling
+// (updateConfigMap guards it and returns an actionable error before the API
+// would reject the write — #71). This backend is intended for small or dev
+// deployments; use the default "sqlite" backend for many artifacts, which stores
+// each row independently and scales without this ceiling.
+//
 // Concurrency: the store holds no process-wide lock. Reads are independent API
 // Gets. Writes are read-modify-write cycles wrapped in retry-on-conflict, so the
 // API server's optimistic concurrency (ResourceVersion) serializes them

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/vibed-project/vibeD/pkg/api"
 
@@ -14,17 +13,29 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 )
+
+// maxConfigMapBytes caps the total size of a store ConfigMap's data. etcd
+// rejects objects over ~1MB, so we guard below that with headroom for keys and
+// API encoding and return an actionable error instead of a cryptic
+// "Request entity too large" that silently bricks the store for writes (#71).
+const maxConfigMapBytes = 900 * 1024
 
 // ConfigMapStore persists artifact metadata in a Kubernetes ConfigMap.
 // Each artifact is stored as a JSON entry keyed by its ID.
 // Versions are stored in a separate ConfigMap named "{name}-versions".
+//
+// Concurrency: the store holds no process-wide lock. Reads are independent API
+// Gets. Writes are read-modify-write cycles wrapped in retry-on-conflict, so the
+// API server's optimistic concurrency (ResourceVersion) serializes them
+// correctly — across replicas too, which a local mutex never could — without
+// blocking on a lock across every remote round-trip (#72).
 type ConfigMapStore struct {
 	client       kubernetes.Interface
 	name         string
 	versionsName string // e.g. "vibed-artifacts-versions"
 	namespace    string
-	mu           sync.Mutex
 }
 
 func init() {
@@ -44,39 +55,35 @@ func NewConfigMapStore(client kubernetes.Interface, name, namespace string) *Con
 }
 
 func (s *ConfigMapStore) Create(ctx context.Context, artifact *api.Artifact) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	cm, err := s.getOrCreateConfigMap(ctx, s.name)
-	if err != nil {
-		return err
-	}
-
-	// Check for name collision
-	for _, v := range cm.Data {
-		var existing api.Artifact
-		if json.Unmarshal([]byte(v), &existing) == nil && existing.Name == artifact.Name {
-			return &api.ErrAlreadyExists{Name: artifact.Name}
-		}
-	}
-
 	data, err := json.Marshal(artifact)
 	if err != nil {
 		return fmt.Errorf("marshaling artifact: %w", err)
 	}
 
-	if cm.Data == nil {
-		cm.Data = make(map[string]string)
-	}
-	cm.Data[artifact.ID] = string(data)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := s.getOrCreateConfigMap(ctx, s.name)
+		if err != nil {
+			return err
+		}
 
-	return s.updateConfigMap(ctx, cm)
+		// Check for name collision
+		for _, v := range cm.Data {
+			var existing api.Artifact
+			if json.Unmarshal([]byte(v), &existing) == nil && existing.Name == artifact.Name {
+				return &api.ErrAlreadyExists{Name: artifact.Name}
+			}
+		}
+
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		cm.Data[artifact.ID] = string(data)
+
+		return s.updateConfigMap(ctx, cm)
+	})
 }
 
 func (s *ConfigMapStore) Get(ctx context.Context, id string) (*api.Artifact, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	cm, err := s.getConfigMap(ctx, s.name)
 	if err != nil {
 		return nil, err
@@ -95,9 +102,6 @@ func (s *ConfigMapStore) Get(ctx context.Context, id string) (*api.Artifact, err
 }
 
 func (s *ConfigMapStore) GetByName(ctx context.Context, name string) (*api.Artifact, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	cm, err := s.getConfigMap(ctx, s.name)
 	if err != nil {
 		return nil, err
@@ -113,9 +117,6 @@ func (s *ConfigMapStore) GetByName(ctx context.Context, name string) (*api.Artif
 }
 
 func (s *ConfigMapStore) List(ctx context.Context, opts ListOptions) (*ListResult, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	cm, err := s.getConfigMap(ctx, s.name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -159,84 +160,85 @@ func (s *ConfigMapStore) List(ctx context.Context, opts ListOptions) (*ListResul
 }
 
 func (s *ConfigMapStore) Update(ctx context.Context, artifact *api.Artifact) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	cm, err := s.getConfigMap(ctx, s.name)
-	if err != nil {
-		return err
-	}
-
-	if _, ok := cm.Data[artifact.ID]; !ok {
-		return &api.ErrNotFound{ArtifactID: artifact.ID}
-	}
-
 	data, err := json.Marshal(artifact)
 	if err != nil {
 		return fmt.Errorf("marshaling artifact: %w", err)
 	}
 
-	cm.Data[artifact.ID] = string(data)
-	return s.updateConfigMap(ctx, cm)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := s.getConfigMap(ctx, s.name)
+		if err != nil {
+			return err
+		}
+		if _, ok := cm.Data[artifact.ID]; !ok {
+			return &api.ErrNotFound{ArtifactID: artifact.ID}
+		}
+		cm.Data[artifact.ID] = string(data)
+		return s.updateConfigMap(ctx, cm)
+	})
 }
 
 func (s *ConfigMapStore) Delete(ctx context.Context, id string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	cm, err := s.getConfigMap(ctx, s.name)
-	if err != nil {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := s.getConfigMap(ctx, s.name)
+		if err != nil {
+			return err
+		}
+		if _, ok := cm.Data[id]; !ok {
+			return &api.ErrNotFound{ArtifactID: id}
+		}
+		delete(cm.Data, id)
+		return s.updateConfigMap(ctx, cm)
+	}); err != nil {
 		return err
 	}
 
-	if _, ok := cm.Data[id]; !ok {
-		return &api.ErrNotFound{ArtifactID: id}
-	}
-
-	delete(cm.Data, id)
-
-	// Clean up version entries
-	vcm, verr := s.getConfigMap(ctx, s.versionsName)
-	if verr == nil && vcm.Data != nil {
+	// Best-effort cleanup of the artifact's version entries in the sibling
+	// ConfigMap (its own read-modify-write; a conflict retries, a missing CM or
+	// other error is non-fatal to the delete).
+	_ = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		vcm, verr := s.getConfigMap(ctx, s.versionsName)
+		if verr != nil || vcm.Data == nil {
+			return nil // nothing to clean; don't retry
+		}
 		prefix := id + "-v"
+		changed := false
 		for key := range vcm.Data {
 			if strings.HasPrefix(key, prefix) {
 				delete(vcm.Data, key)
+				changed = true
 			}
 		}
-		_ = s.updateConfigMap(ctx, vcm)
-	}
+		if !changed {
+			return nil
+		}
+		return s.updateConfigMap(ctx, vcm)
+	})
 
-	return s.updateConfigMap(ctx, cm)
+	return nil
 }
 
 func (s *ConfigMapStore) CreateVersion(ctx context.Context, version *api.ArtifactVersion) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	cm, err := s.getOrCreateConfigMap(ctx, s.versionsName)
-	if err != nil {
-		return err
-	}
-
 	data, err := json.Marshal(version)
 	if err != nil {
 		return fmt.Errorf("marshaling version: %w", err)
 	}
-
 	key := fmt.Sprintf("%s-v%d", version.ArtifactID, version.Version)
-	if cm.Data == nil {
-		cm.Data = make(map[string]string)
-	}
-	cm.Data[key] = string(data)
 
-	return s.updateConfigMap(ctx, cm)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := s.getOrCreateConfigMap(ctx, s.versionsName)
+		if err != nil {
+			return err
+		}
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		cm.Data[key] = string(data)
+		return s.updateConfigMap(ctx, cm)
+	})
 }
 
 func (s *ConfigMapStore) ListVersions(ctx context.Context, artifactID string) ([]api.ArtifactVersion, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	cm, err := s.getConfigMap(ctx, s.versionsName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -267,9 +269,6 @@ func (s *ConfigMapStore) ListVersions(ctx context.Context, artifactID string) ([
 }
 
 func (s *ConfigMapStore) GetVersion(ctx context.Context, artifactID string, version int) (*api.ArtifactVersion, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	cm, err := s.getConfigMap(ctx, s.versionsName)
 	if err != nil {
 		return nil, &api.ErrVersionNotFound{ArtifactID: artifactID, Version: version}
@@ -323,8 +322,18 @@ func (s *ConfigMapStore) getOrCreateConfigMap(ctx context.Context, name string) 
 }
 
 func (s *ConfigMapStore) updateConfigMap(ctx context.Context, cm *corev1.ConfigMap) error {
-	_, err := s.client.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{})
-	if err != nil {
+	// Guard the etcd ~1MB object ceiling before the write: past it, the API
+	// rejects every Update with a cryptic "Request entity too large" and the
+	// store is bricked for writes. Fail early with an actionable error (#71).
+	total := 0
+	for k, v := range cm.Data {
+		total += len(k) + len(v)
+	}
+	if total > maxConfigMapBytes {
+		return fmt.Errorf("artifact-store ConfigMap %q would be %d bytes, over the %d-byte safety limit (etcd caps objects near 1MB); switch store.backend to \"sqlite\" for this many artifacts", cm.Name, total, maxConfigMapBytes)
+	}
+
+	if _, err := s.client.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("updating configmap: %w", err)
 	}
 	return nil

--- a/internal/store/configmap_unit_test.go
+++ b/internal/store/configmap_unit_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/vibed-project/vibeD/pkg/api"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newFakeConfigMapStore() *ConfigMapStore {
+	return NewConfigMapStore(fake.NewSimpleClientset(), "vibed-artifacts", "vibed-system")
+}
+
+// TestConfigMapStore_CRUD exercises the lock-free reads + retry-wrapped writes
+// (#72) end to end against the fake clientset: the round-trips must still behave.
+func TestConfigMapStore_CRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newFakeConfigMapStore()
+
+	a := &api.Artifact{ID: "a1", Name: "app-one", OwnerID: "alice", Status: api.StatusRunning}
+	if err := s.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Duplicate name is rejected (not a conflict → not retried).
+	if err := s.Create(ctx, &api.Artifact{ID: "a2", Name: "app-one"}); err == nil {
+		t.Error("Create with duplicate name should fail")
+	}
+
+	got, err := s.Get(ctx, "a1")
+	if err != nil || got.Name != "app-one" {
+		t.Fatalf("Get: %v, %+v", err, got)
+	}
+	if byName, err := s.GetByName(ctx, "app-one"); err != nil || byName.ID != "a1" {
+		t.Fatalf("GetByName: %v, %+v", err, byName)
+	}
+
+	a.Status = api.StatusFailed
+	if err := s.Update(ctx, a); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got, _ := s.Get(ctx, "a1"); got.Status != api.StatusFailed {
+		t.Errorf("after Update status = %q, want failed", got.Status)
+	}
+
+	list, err := s.List(ctx, ListOptions{AdminView: true})
+	if err != nil || list.Total != 1 {
+		t.Fatalf("List: %v, total=%d", err, list.Total)
+	}
+
+	if err := s.Delete(ctx, "a1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Get(ctx, "a1"); err == nil {
+		t.Error("Get after Delete should fail")
+	}
+	// Deleting a missing artifact is ErrNotFound, not a retry storm.
+	if err := s.Delete(ctx, "missing"); err == nil {
+		t.Error("Delete of missing artifact should return ErrNotFound")
+	}
+}
+
+// TestConfigMapStore_SizeGuard locks in #71: a write that would push the store
+// ConfigMap past the etcd safety limit is rejected with an actionable error
+// before hitting the API, instead of bricking on a cryptic "entity too large".
+func TestConfigMapStore_SizeGuard(t *testing.T) {
+	ctx := context.Background()
+	s := newFakeConfigMapStore()
+
+	// One artifact whose serialized JSON alone exceeds the limit. StaticFiles is
+	// a persisted string field (EnvVars/SecretRefs are json:"-" in this store).
+	big := &api.Artifact{
+		ID:          "big",
+		Name:        "big-app",
+		StaticFiles: strings.Repeat("x", maxConfigMapBytes+1),
+	}
+	err := s.Create(ctx, big)
+	if err == nil {
+		t.Fatal("Create of an oversized artifact should be rejected by the size guard")
+	}
+	if !strings.Contains(err.Error(), "safety limit") {
+		t.Errorf("error = %q, want the size-limit guard message", err)
+	}
+	// The store is not bricked: a normal artifact still writes fine.
+	if err := s.Create(ctx, &api.Artifact{ID: "ok", Name: "ok-app"}); err != nil {
+		t.Errorf("normal Create after a rejected oversized write should succeed: %v", err)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -907,16 +907,11 @@ func (s *SQLiteStore) GetShareLink(ctx context.Context, token string) (*api.Shar
 	return &link, passwordHash, nil
 }
 
-// maxShareLinksPerList bounds the share-link list for one artifact. Share links
-// are per-artifact and few in practice, so rather than thread pagination through
-// the deploy/orchestrator wrappers, a fixed ceiling keeps the result set bounded
-// (#80) — high enough never to truncate a real app's links.
-const maxShareLinksPerList = 500
-
-func (s *SQLiteStore) ListShareLinks(ctx context.Context, artifactID string) ([]api.ShareLink, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT token, artifact_id, created_by, password, expires_at, created_at, revoked FROM share_links WHERE artifact_id=? ORDER BY created_at DESC LIMIT ?`,
-		artifactID, maxShareLinksPerList)
+func (s *SQLiteStore) ListShareLinks(ctx context.Context, artifactID string, limit, offset int) ([]api.ShareLink, error) {
+	query, args := appendPage(
+		`SELECT token, artifact_id, created_by, password, expires_at, created_at, revoked FROM share_links WHERE artifact_id=? ORDER BY created_at DESC`,
+		[]interface{}{artifactID}, limit, offset)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("listing share links: %w", err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -790,7 +790,19 @@ func (s *SQLiteStore) GetUserByName(ctx context.Context, name string) (*api.User
 	return &u, nil
 }
 
-func (s *SQLiteStore) ListUsers(ctx context.Context, departmentID string) ([]api.User, error) {
+// appendPage adds LIMIT/OFFSET to query when limit > 0 (limit <= 0 means "all",
+// matching artifact ListOptions). A negative offset is clamped to 0.
+func appendPage(query string, args []interface{}, limit, offset int) (string, []interface{}) {
+	if limit <= 0 {
+		return query, args
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return query + " LIMIT ? OFFSET ?", append(args, limit, offset)
+}
+
+func (s *SQLiteStore) ListUsers(ctx context.Context, departmentID string, limit, offset int) ([]api.User, error) {
 	query := `SELECT id, name, email, role, status, provider, department_id, created_at, updated_at FROM users`
 	var args []interface{}
 	if departmentID != "" {
@@ -798,6 +810,7 @@ func (s *SQLiteStore) ListUsers(ctx context.Context, departmentID string) ([]api
 		args = append(args, departmentID)
 	}
 	query += ` ORDER BY name`
+	query, args = appendPage(query, args, limit, offset)
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -894,9 +907,16 @@ func (s *SQLiteStore) GetShareLink(ctx context.Context, token string) (*api.Shar
 	return &link, passwordHash, nil
 }
 
+// maxShareLinksPerList bounds the share-link list for one artifact. Share links
+// are per-artifact and few in practice, so rather than thread pagination through
+// the deploy/orchestrator wrappers, a fixed ceiling keeps the result set bounded
+// (#80) — high enough never to truncate a real app's links.
+const maxShareLinksPerList = 500
+
 func (s *SQLiteStore) ListShareLinks(ctx context.Context, artifactID string) ([]api.ShareLink, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT token, artifact_id, created_by, password, expires_at, created_at, revoked FROM share_links WHERE artifact_id=? ORDER BY created_at DESC`, artifactID)
+		`SELECT token, artifact_id, created_by, password, expires_at, created_at, revoked FROM share_links WHERE artifact_id=? ORDER BY created_at DESC LIMIT ?`,
+		artifactID, maxShareLinksPerList)
 	if err != nil {
 		return nil, fmt.Errorf("listing share links: %w", err)
 	}
@@ -985,9 +1005,9 @@ func (s *SQLiteStore) GetDepartmentByName(ctx context.Context, name string) (*ap
 	return &d, nil
 }
 
-func (s *SQLiteStore) ListDepartments(ctx context.Context) ([]api.Department, error) {
-	rows, err := s.db.QueryContext(ctx,
-	        `SELECT id, name, namespace, created_at, updated_at FROM departments ORDER BY name`)
+func (s *SQLiteStore) ListDepartments(ctx context.Context, limit, offset int) ([]api.Department, error) {
+	query, args := appendPage(`SELECT id, name, namespace, created_at, updated_at FROM departments ORDER BY name`, nil, limit, offset)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 	        return nil, fmt.Errorf("listing departments: %w", err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -76,6 +76,11 @@ CREATE TABLE IF NOT EXISTS artifact_versions (
 
 CREATE INDEX IF NOT EXISTS idx_artifacts_status ON artifacts(status);
 CREATE INDEX IF NOT EXISTS idx_artifacts_owner_id ON artifacts(owner_id);
+-- The List hot path orders by created_at DESC, often with a status filter.
+-- A plain created_at index serves the unfiltered (admin) listing; the composite
+-- serves "WHERE status = ? ORDER BY created_at DESC" without a filesort.
+CREATE INDEX IF NOT EXISTS idx_artifacts_created_at ON artifacts(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_artifacts_status_created ON artifacts(status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_artifact_versions_artifact_id ON artifact_versions(artifact_id);
 CREATE INDEX IF NOT EXISTS idx_share_links_artifact_id ON share_links(artifact_id);
 
@@ -181,6 +186,15 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 			db.Close()
 			return nil, fmt.Errorf("migrating users table (api_key_hash): %w", err)
 		}
+	}
+
+	// Index the api_key_hash auth-lookup path (GetUserByAPIKeyHash runs on every
+	// API-key request). Created here rather than in the base schema because the
+	// column is added by the migration above. Partial index: the lookup always
+	// filters api_key_hash != '', and most rows have no key, so this stays small.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_users_api_key_hash ON users(api_key_hash) WHERE api_key_hash != ''`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("creating api_key_hash index: %w", err)
 	}
 
 	// Migration: add the enriched audit columns if missing (older DBs).

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -84,6 +84,18 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_status_created ON artifacts(status, cre
 CREATE INDEX IF NOT EXISTS idx_artifact_versions_artifact_id ON artifact_versions(artifact_id);
 CREATE INDEX IF NOT EXISTS idx_share_links_artifact_id ON share_links(artifact_id);
 
+-- artifact_shares normalizes artifacts.shared_with (a JSON array) into an
+-- indexed join table so the List "shared with me" filter is an indexed lookup
+-- instead of a "shared_with LIKE '%\"owner\"%'" full-table scan (#80). The JSON
+-- column stays the source of truth for an artifact's SharedWith; this table is a
+-- derived query index kept in sync on every write and backfilled on open.
+CREATE TABLE IF NOT EXISTS artifact_shares (
+        artifact_id TEXT NOT NULL,
+        owner       TEXT NOT NULL,
+        PRIMARY KEY (artifact_id, owner)
+);
+CREATE INDEX IF NOT EXISTS idx_artifact_shares_owner ON artifact_shares(owner);
+
 CREATE TABLE IF NOT EXISTS departments (
         id         TEXT PRIMARY KEY,
         name       TEXT UNIQUE NOT NULL,
@@ -204,6 +216,24 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 				db.Close()
 				return nil, fmt.Errorf("migrating audit_events table (%s): %w", col, err)
 			}
+		}
+	}
+
+	// Backfill the artifact_shares index from the existing shared_with JSON on an
+	// upgraded DB. Guarded on an empty table so it runs once; INSERT OR IGNORE +
+	// the composite PK keep it idempotent regardless. json_each expands each
+	// artifact's shared_with array into (artifact_id, owner) rows.
+	var shareRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM artifact_shares`).Scan(&shareRows); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("checking artifact_shares: %w", err)
+	}
+	if shareRows == 0 {
+		if _, err := db.Exec(`INSERT OR IGNORE INTO artifact_shares (artifact_id, owner)
+			SELECT a.id, je.value FROM artifacts a, json_each(a.shared_with) je
+			WHERE a.shared_with != '' AND a.shared_with != '[]'`); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("backfilling artifact_shares: %w", err)
 		}
 	}
 
@@ -334,7 +364,13 @@ func (s *SQLiteStore) Create(ctx context.Context, artifact *api.Artifact) error 
 		return fmt.Errorf("marshaling shared_with: %w", err)
 	}
 
-	_, err = s.stmtCreateArtifact.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Stmt(s.stmtCreateArtifact).ExecContext(ctx,
 	        artifact.ID, artifact.Name, artifact.OwnerID, artifact.Namespace, string(artifact.Status),
 	        string(artifact.Target), string(artifact.Mode), artifact.ImageRef, artifact.URL, artifact.Port,
 	        string(envVars), string(secretRefs), artifact.Language, artifact.StaticFiles, artifact.Error,
@@ -346,6 +382,29 @@ func (s *SQLiteStore) Create(ctx context.Context, artifact *api.Artifact) error 
 			return &api.ErrAlreadyExists{Name: artifact.Name}
 		}
 		return fmt.Errorf("inserting artifact: %w", err)
+	}
+	if err := syncArtifactShares(ctx, tx, artifact.ID, artifact.SharedWith); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// syncArtifactShares makes the artifact_shares index rows for artifactID exactly
+// match shared (the artifact's SharedWith). Runs inside the artifact's write
+// transaction so the JSON column and its index stay consistent.
+func syncArtifactShares(ctx context.Context, tx *sql.Tx, artifactID string, shared []string) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM artifact_shares WHERE artifact_id = ?`, artifactID); err != nil {
+		return fmt.Errorf("clearing artifact shares: %w", err)
+	}
+	for _, owner := range shared {
+		if owner == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO artifact_shares (artifact_id, owner) VALUES (?, ?)`,
+			artifactID, owner); err != nil {
+			return fmt.Errorf("inserting artifact share: %w", err)
+		}
 	}
 	return nil
 }
@@ -386,8 +445,11 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) (*ListResult, 
 	}
 
 	if !opts.AdminView && opts.OwnerID != "" {
-		conditions = append(conditions, "(owner_id = ? OR shared_with LIKE ?)")
-		args = append(args, opts.OwnerID, `%"`+opts.OwnerID+`"%`)
+		// Owned directly, or shared with the caller via the indexed join table.
+		// The IN-subquery hits idx_artifact_shares_owner instead of the old
+		// "shared_with LIKE '%\"owner\"%'" full-table scan (#80).
+		conditions = append(conditions, "(owner_id = ? OR id IN (SELECT artifact_id FROM artifact_shares WHERE owner = ?))")
+		args = append(args, opts.OwnerID, opts.OwnerID)
 	}
 
 	whereClause := ""
@@ -471,7 +533,13 @@ func (s *SQLiteStore) Update(ctx context.Context, artifact *api.Artifact) error 
 		return fmt.Errorf("marshaling shared_with: %w", err)
 	}
 
-	res, err := s.stmtUpdateArtifact.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Stmt(s.stmtUpdateArtifact).ExecContext(ctx,
 	        artifact.Name, artifact.OwnerID, artifact.Namespace, string(artifact.Status),
 	        string(artifact.Target), string(artifact.Mode), artifact.ImageRef, artifact.URL, artifact.Port,
 	        string(envVars), string(secretRefs), artifact.Language, artifact.StaticFiles, artifact.Error,
@@ -486,7 +554,10 @@ func (s *SQLiteStore) Update(ctx context.Context, artifact *api.Artifact) error 
 	if n == 0 {
 		return &api.ErrNotFound{ArtifactID: artifact.ID}
 	}
-	return nil
+	if err := syncArtifactShares(ctx, tx, artifact.ID, artifact.SharedWith); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
@@ -507,6 +578,10 @@ func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
 
 	if _, err := tx.ExecContext(ctx, "DELETE FROM artifact_versions WHERE artifact_id = ?", id); err != nil {
 		return fmt.Errorf("deleting versions: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM artifact_shares WHERE artifact_id = ?", id); err != nil {
+		return fmt.Errorf("deleting shares: %w", err)
 	}
 
 	return tx.Commit()

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -278,6 +279,50 @@ func TestSQLiteStore_SharesBackfillOnOpen(t *testing.T) {
 	back, err := s2.List(ctx, ListOptions{OwnerID: "bob"})
 	require.NoError(t, err)
 	assert.Len(t, back.Artifacts, 1, "backfill should restore bob's shared view")
+}
+
+// TestSQLiteStore_ListPagination locks in the #80 pagination: limit<=0 returns
+// all, limit>0 pages with offset, for both ListUsers and ListDepartments.
+func TestSQLiteStore_ListPagination(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Second)
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, s.CreateUser(ctx, &api.User{
+			ID: fmt.Sprintf("id-%d", i), Name: fmt.Sprintf("u%d", i),
+			Role: "user", Status: "active", CreatedAt: now, UpdatedAt: now,
+		}))
+	}
+
+	all, err := s.ListUsers(ctx, "", 0, 0) // 0 = all
+	require.NoError(t, err)
+	assert.Len(t, all, 5)
+
+	page1, err := s.ListUsers(ctx, "", 2, 0)
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+	assert.Equal(t, "u0", page1[0].Name)
+	assert.Equal(t, "u1", page1[1].Name)
+
+	page2, err := s.ListUsers(ctx, "", 2, 2)
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	assert.Equal(t, "u2", page2[0].Name)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, s.CreateDepartment(ctx, &api.Department{
+			ID: fmt.Sprintf("d-%d", i), Name: fmt.Sprintf("dept%d", i),
+			CreatedAt: now, UpdatedAt: now,
+		}))
+	}
+	depAll, err := s.ListDepartments(ctx, 0, 0)
+	require.NoError(t, err)
+	assert.Len(t, depAll, 3)
+	depPage, err := s.ListDepartments(ctx, 1, 1)
+	require.NoError(t, err)
+	require.Len(t, depPage, 1)
+	assert.Equal(t, "dept1", depPage[0].Name)
 }
 
 func TestSQLiteStore_Versions(t *testing.T) {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -223,6 +223,61 @@ func TestSQLiteStore_SharedWith(t *testing.T) {
 	got, err := s.Get(ctx, "a1")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"bob", "charlie"}, got.SharedWith)
+
+	// Update that revokes charlie's access re-syncs the join table: charlie can
+	// no longer see it, bob still can.
+	a.SharedWith = []string{"bob"}
+	require.NoError(t, s.Update(ctx, a))
+	charlieList, err := s.List(ctx, ListOptions{OwnerID: "charlie"})
+	require.NoError(t, err)
+	assert.Empty(t, charlieList.Artifacts, "revoked share must drop from the index")
+	bobList, err = s.List(ctx, ListOptions{OwnerID: "bob"})
+	require.NoError(t, err)
+	assert.Len(t, bobList.Artifacts, 1)
+
+	// The shared-list filter must use the join-table index, not a scan.
+	var plan string
+	rows, err := s.db.Query(`EXPLAIN QUERY PLAN SELECT id FROM artifacts WHERE (owner_id = ? OR id IN (SELECT artifact_id FROM artifact_shares WHERE owner = ?))`, "x", "x")
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+		plan += detail + "\n"
+	}
+	assert.Contains(t, plan, "idx_artifact_shares_owner", "shared-list subquery should use the owner index; plan:\n"+plan)
+}
+
+// TestSQLiteStore_SharesBackfillOnOpen locks in the #80 migration: an upgraded
+// DB that has shared_with JSON but an empty artifact_shares index gets the index
+// backfilled on open, so the shared-list filter keeps working.
+func TestSQLiteStore_SharesBackfillOnOpen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "backfill.db")
+	ctx := context.Background()
+
+	s1, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	a := testArtifact("a1", "shared-app")
+	a.OwnerID = "alice"
+	a.SharedWith = []string{"bob"}
+	require.NoError(t, s1.Create(ctx, a))
+
+	// Simulate a pre-migration DB: the JSON share exists but the index doesn't.
+	_, err = s1.db.Exec(`DELETE FROM artifact_shares`)
+	require.NoError(t, err)
+	gone, err := s1.List(ctx, ListOptions{OwnerID: "bob"})
+	require.NoError(t, err)
+	require.Empty(t, gone.Artifacts, "with the index cleared, bob shouldn't resolve the share")
+	require.NoError(t, s1.Close())
+
+	// Reopen: the backfill repopulates artifact_shares from shared_with JSON.
+	s2, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer s2.Close()
+	back, err := s2.List(ctx, ListOptions{OwnerID: "bob"})
+	require.NoError(t, err)
+	assert.Len(t, back.Artifacts, 1, "backfill should restore bob's shared view")
 }
 
 func TestSQLiteStore_Versions(t *testing.T) {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -277,6 +277,40 @@ func TestSQLiteStore_Versions(t *testing.T) {
 	assert.IsType(t, &api.ErrVersionNotFound{}, err)
 }
 
+// TestSQLiteStore_PerfIndexes locks in the indexes added for issue #80: the
+// created_at ordering path and the api_key_hash auth lookup must be indexed so
+// they don't degrade into full-table scans as the tables grow.
+func TestSQLiteStore_PerfIndexes(t *testing.T) {
+	s := newTestSQLiteStore(t)
+
+	want := []string{
+		"idx_artifacts_created_at",
+		"idx_artifacts_status_created",
+		"idx_users_api_key_hash",
+	}
+	for _, name := range want {
+		var got string
+		err := s.db.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, name,
+		).Scan(&got)
+		require.NoErrorf(t, err, "index %q should exist", name)
+		assert.Equal(t, name, got)
+	}
+
+	// The api_key_hash lookup must actually use its index, not scan the table.
+	var plan string
+	rows, err := s.db.Query(`EXPLAIN QUERY PLAN SELECT id FROM users WHERE api_key_hash = ? AND api_key_hash != ''`, "x")
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+		plan += detail + "\n"
+	}
+	assert.Contains(t, plan, "idx_users_api_key_hash", "api-key lookup should use its index; plan was:\n"+plan)
+}
+
 func TestSQLiteStore_Persistence(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "persist.db")
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,14 +11,17 @@ type UserStore interface {
 	CreateUser(ctx context.Context, user *api.User) error
 	GetUser(ctx context.Context, id string) (*api.User, error)
 	GetUserByName(ctx context.Context, name string) (*api.User, error)
-	ListUsers(ctx context.Context, departmentID string) ([]api.User, error)
+	// ListUsers lists users (optionally scoped to a department). limit<=0
+	// returns all; limit>0 pages with offset, matching artifact ListOptions.
+	ListUsers(ctx context.Context, departmentID string, limit, offset int) ([]api.User, error)
 	GetUserByAPIKeyHash(ctx context.Context, hash string) (*api.User, error)
 	UpdateUser(ctx context.Context, user *api.User) error
 
 	CreateDepartment(ctx context.Context, dept *api.Department) error
 	GetDepartment(ctx context.Context, id string) (*api.Department, error)
 	GetDepartmentByName(ctx context.Context, name string) (*api.Department, error)
-	ListDepartments(ctx context.Context) ([]api.Department, error)
+	// ListDepartments lists departments. limit<=0 returns all; limit>0 pages.
+	ListDepartments(ctx context.Context, limit, offset int) ([]api.Department, error)
 	UpdateDepartment(ctx context.Context, dept *api.Department) error
 	DeleteDepartment(ctx context.Context, id string) error
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,7 +30,9 @@ type UserStore interface {
 type ShareLinkStore interface {
 	CreateShareLink(ctx context.Context, link *api.ShareLink, passwordHash string) error
 	GetShareLink(ctx context.Context, token string) (*api.ShareLink, string, error) // returns link + password hash
-	ListShareLinks(ctx context.Context, artifactID string) ([]api.ShareLink, error)
+	// ListShareLinks lists an artifact's share links. limit<=0 returns all;
+	// limit>0 pages with offset.
+	ListShareLinks(ctx context.Context, artifactID string, limit, offset int) ([]api.ShareLink, error)
 	RevokeShareLink(ctx context.Context, token string) error
 }
 

--- a/pkg/server/noauth_guard_test.go
+++ b/pkg/server/noauth_guard_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/vibed-project/vibeD/internal/config"
+)
+
+func TestIsLoopbackBind(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:8080", true},
+		{"localhost:8080", true},
+		{"[::1]:8080", true},
+		{":8080", false},        // all interfaces
+		{"0.0.0.0:8080", false}, // all interfaces
+		{"[::]:8080", false},    // all interfaces
+		{"10.0.0.5:8080", false},
+		{"example.com:8080", false}, // unresolvable hostname → fail safe
+	}
+	for _, c := range cases {
+		if got := isLoopbackBind(c.addr); got != c.want {
+			t.Errorf("isLoopbackBind(%q) = %v, want %v", c.addr, got, c.want)
+		}
+	}
+}
+
+// TestCheckNoAuthBindSafety covers the #55 startup guard: no-auth on a
+// non-loopback bind is refused unless devInsecure is set; every other
+// combination is allowed to start.
+func TestCheckNoAuthBindSafety(t *testing.T) {
+	cfg := func(enabled, devInsecure bool, addr string) *config.Config {
+		c := &config.Config{}
+		c.Auth.Enabled = enabled
+		c.Auth.DevInsecure = devInsecure
+		c.Server.HTTPAddr = addr
+		return c
+	}
+
+	cases := []struct {
+		name    string
+		cfg     *config.Config
+		wantErr bool
+	}{
+		{"auth on, public bind — ok", cfg(true, false, ":8080"), false},
+		{"auth off, loopback — ok", cfg(false, false, "127.0.0.1:8080"), false},
+		{"auth off, public bind, no opt-in — refuse", cfg(false, false, ":8080"), true},
+		{"auth off, public bind, devInsecure — ok", cfg(false, true, ":8080"), false},
+		{"auth off, wildcard IP, no opt-in — refuse", cfg(false, false, "0.0.0.0:8080"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := checkNoAuthBindSafety(c.cfg)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("checkNoAuthBindSafety = %v, wantErr=%v", err, c.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -500,6 +500,13 @@ func runHTTPServer(ctx context.Context, cfg *config.Config, mcpServer *mcp.Serve
 	// Apply rate limiting (after auth so we can key by user)
 	if cfg.Server.RateLimit.Enabled {
 		handler = middleware.RateLimiter(ctx, cfg.Server.RateLimit, m)(handler)
+	} else if cfg.Server.Transport != "stdio" {
+		// Rate limiting is off on a network-facing transport: the deploy path and
+		// all of /v1/* are unthrottled, so one authenticated user can flood the
+		// expensive deploy path (#50). We don't silently flip the default, but we
+		// make the exposure loud.
+		logger.Warn("rate limiting is DISABLED on a network transport; /v1/* (including the deploy path) is unthrottled — set server.rateLimit.enabled=true in production",
+			"transport", cfg.Server.Transport)
 	}
 
 	// Apply OTel HTTP tracing middleware (extracts/injects trace context)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -427,6 +427,7 @@ func runHTTPServer(ctx context.Context, cfg *config.Config, mcpServer *mcp.Serve
 	if deploySvc != nil {
 		vibedAPI.Deploy = deploySvc
 		vibedAPI.MaxConcurrentLogStreamsPerUser = cfg.Limits.MaxConcurrentLogStreamsPerUser
+		vibedAPI.MaxConcurrentLogStreamsGlobal = cfg.Limits.MaxConcurrentLogStreamsGlobal
 		// Served tarball backend: vibeD serves the source blobs the agent pulls.
 		if blob, berr := tarball.NewBlobHandler(cfg.Storage.Tarball); berr != nil {
 			logger.Warn("blob handler init failed", "error", berr)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -127,6 +128,20 @@ func Run(cfg *config.Config, logger *slog.Logger) {
 		"auth", cfg.Auth.Enabled,
 		"tls", cfg.Auth.TLS.Enabled,
 	)
+
+	// Fail fast on the auth-disabled-on-a-public-bind misconfiguration (#55):
+	// no-auth mode treats every request as admin, so a non-loopback bind would
+	// expose the full admin API unauthenticated. Requires an explicit
+	// auth.devInsecure opt-in to proceed.
+	if err := checkNoAuthBindSafety(cfg); err != nil {
+		logger.Error("insecure configuration", "error", err)
+		os.Exit(1)
+	}
+	if !cfg.Auth.Enabled && !isLoopbackBind(cfg.Server.HTTPAddr) {
+		// Reached only with auth.devInsecure=true; make the posture loud on every boot.
+		logger.Warn("SECURITY: auth is disabled on a non-loopback bind (auth.devInsecure=true) — every request is treated as admin; ensure this listener is network-isolated (NetworkPolicy/loopback) and never reachable by untrusted clients",
+			"httpAddr", cfg.Server.HTTPAddr)
+	}
 
 	// Initialize metrics and health checker
 	m := metrics.New()
@@ -533,6 +548,43 @@ func runHTTPServer(ctx context.Context, cfg *config.Config, mcpServer *mcp.Serve
 			os.Exit(1)
 		}
 	}
+}
+
+// checkNoAuthBindSafety returns a non-nil error when the server is configured
+// with authentication disabled on a non-loopback bind and the operator has not
+// explicitly opted in via auth.devInsecure. In that configuration every request
+// is treated as admin (NoAuthAdminMiddleware), so a network-reachable bind would
+// expose the full admin API unauthenticated (#55).
+func checkNoAuthBindSafety(cfg *config.Config) error {
+	if cfg.Auth.Enabled || cfg.Auth.DevInsecure {
+		return nil
+	}
+	if isLoopbackBind(cfg.Server.HTTPAddr) {
+		return nil
+	}
+	return fmt.Errorf("auth is disabled (auth.enabled=false) but the server binds a non-loopback address %q, which exposes the full admin API unauthenticated to the network; enable auth (auth.enabled=true), bind a loopback address (e.g. 127.0.0.1:8080), or set auth.devInsecure=true to override for a trusted/network-isolated environment", cfg.Server.HTTPAddr)
+}
+
+// isLoopbackBind reports whether addr (a host:port as accepted by
+// http.Server.Addr) binds only the loopback interface. An empty host (":8080")
+// or a wildcard (0.0.0.0, ::) binds all interfaces and is NOT loopback. A
+// non-IP, non-"localhost" hostname can't be proven loopback, so it returns false
+// (fail safe — the caller then requires the explicit opt-in).
+func isLoopbackBind(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr // maybe a bare host with no port
+	}
+	switch host {
+	case "":
+		return false
+	case "localhost":
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // bootstrapAPIKeyUsers seeds the user store with users from configured API keys.

--- a/pkg/vibedapi/http/deploy_endpoints_test.go
+++ b/pkg/vibedapi/http/deploy_endpoints_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -450,12 +451,42 @@ func TestLogStreamCapBlocksOverLimit(t *testing.T) {
 	}
 }
 
-func TestLogStreamCapDisabled(t *testing.T) {
-	srv := &Server{MaxConcurrentLogStreamsPerUser: 0} // 0 = unlimited
-	for i := 0; i < 100; i++ {
+// TestLogStreamCapDefaultsWhenUnset locks in issue #81: a 0/unset per-user cap
+// must fall back to the safe server default, NOT unlimited. Acquires succeed up
+// to the default and are rejected past it.
+func TestLogStreamCapDefaultsWhenUnset(t *testing.T) {
+	srv := &Server{MaxConcurrentLogStreamsPerUser: 0} // 0 -> safe default, not unlimited
+	for i := 0; i < defaultMaxLogStreamsPerUser; i++ {
 		if !srv.acquireLogStream("alice") {
-			t.Fatalf("acquire %d failed with cap disabled", i)
+			t.Fatalf("acquire %d should succeed under the default cap", i)
 		}
+	}
+	if srv.acquireLogStream("alice") {
+		t.Fatalf("acquire past the default per-user cap (%d) must be rejected", defaultMaxLogStreamsPerUser)
+	}
+}
+
+// TestLogStreamGlobalCap locks in the global cap (issue #81): even spread across
+// distinct users (each under its per-user cap), total streams are bounded so
+// they can't collectively exhaust controller memory.
+func TestLogStreamGlobalCap(t *testing.T) {
+	// Per-user cap high enough that the global cap is what bites; global cap
+	// small so the test is cheap.
+	srv := &Server{MaxConcurrentLogStreamsPerUser: 100, MaxConcurrentLogStreamsGlobal: 3}
+
+	for i := 0; i < 3; i++ {
+		if !srv.acquireLogStream(fmt.Sprintf("user-%d", i)) {
+			t.Fatalf("acquire %d should succeed under the global cap", i)
+		}
+	}
+	// Fourth distinct user is under its own per-user cap but over the global cap.
+	if srv.acquireLogStream("user-4") {
+		t.Fatal("acquire past the global cap must be rejected even for a fresh user")
+	}
+	// Releasing one frees a global slot.
+	srv.releaseLogStream("user-0")
+	if !srv.acquireLogStream("user-4") {
+		t.Fatal("after a release, a global slot must free up")
 	}
 }
 

--- a/pkg/vibedapi/http/deploy_endpoints_test.go
+++ b/pkg/vibedapi/http/deploy_endpoints_test.go
@@ -197,10 +197,15 @@ func TestDeployEndpoint401WithoutOwner(t *testing.T) {
 
 func TestGetAndListAndDelete(t *testing.T) {
 	h, c := newDeployRouter(t, "alice@example.com")
-	// Seed a ready app directly.
+	// Seed a ready app directly, carrying the vibed.dev/owner label the deploy
+	// path always stamps — Service.List now pre-filters on it server-side (#74).
 	app := &vibedv1.VibedApp{
-		ObjectMeta: metav1.ObjectMeta{Name: "seeded", Namespace: "vibed-apps"},
-		Spec:       vibedv1.VibedAppSpec{Owner: "alice@example.com", Runtime: vibedv1.Runtime{Lane: vibedv1.LaneGeneral, Template: "node-24"}},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "seeded",
+			Namespace: "vibed-apps",
+			Labels:    map[string]string{vibedv1.LabelOwner: vibedv1.SanitizeLabel("alice@example.com")},
+		},
+		Spec: vibedv1.VibedAppSpec{Owner: "alice@example.com", Runtime: vibedv1.Runtime{Lane: vibedv1.LaneGeneral, Template: "node-24"}},
 	}
 	if err := c.Create(context.Background(), app); err != nil {
 		t.Fatal(err)

--- a/pkg/vibedapi/http/deploy_endpoints_test.go
+++ b/pkg/vibedapi/http/deploy_endpoints_test.go
@@ -355,8 +355,8 @@ func TestStreamLogsSSE(t *testing.T) {
 // pulling the internal package in.
 type quotaDenied struct{}
 
-func (quotaDenied) Authorize(context.Context, tenant.Tenant, string, bool) (string, error) {
-	return "", quotaErr{}
+func (quotaDenied) Authorize(context.Context, tenant.Tenant, string, bool) (string, func(), error) {
+	return "", func() {}, quotaErr{}
 }
 
 type quotaErr struct{}

--- a/pkg/vibedapi/http/server.go
+++ b/pkg/vibedapi/http/server.go
@@ -48,44 +48,74 @@ type Server struct {
 	Deploy *deploy.Service
 
 	// MaxConcurrentLogStreamsPerUser caps simultaneous /v1/logs SSE
-	// connections per authenticated user. 0 disables the cap (legacy
-	// behavior). Hard-coded gate against a trivial DoS where one user opens
-	// many streams to exhaust controller memory.
+	// connections per authenticated user. <=0 falls back to
+	// defaultMaxLogStreamsPerUser rather than disabling the cap — an
+	// unlimited per-user count is a trivial DoS (each stream holds a goroutine
+	// and a 1 MB scanner buffer).
 	MaxConcurrentLogStreamsPerUser int
 
-	logStreamMu sync.Mutex
-	logStreams  map[string]int // userID -> current open count
+	// MaxConcurrentLogStreamsGlobal caps simultaneous /v1/logs SSE connections
+	// across ALL users, so many users (or many distinct identities) can't
+	// collectively exhaust controller memory even while each stays under its
+	// per-user cap. <=0 falls back to defaultMaxLogStreamsGlobal.
+	MaxConcurrentLogStreamsGlobal int
+
+	logStreamMu    sync.Mutex
+	logStreams     map[string]int // userID -> current open count
+	logStreamTotal int            // total open across all users
 
 	Logger *slog.Logger
 }
 
-// acquireLogStream reserves one stream slot for user. Returns false (over
-// cap) when MaxConcurrentLogStreamsPerUser > 0 and the user is already at it.
-// Each acquire must be paired with releaseLogStream.
-func (s *Server) acquireLogStream(user string) bool {
-	if s.MaxConcurrentLogStreamsPerUser <= 0 {
-		return true
+// Safe defaults applied when the corresponding cap is left <=0. Neither cap can
+// be disabled: an uncapped log-stream count is a memory-exhaustion DoS.
+const (
+	defaultMaxLogStreamsPerUser = 10
+	defaultMaxLogStreamsGlobal  = 100
+)
+
+func (s *Server) perUserLogStreamLimit() int {
+	if s.MaxConcurrentLogStreamsPerUser > 0 {
+		return s.MaxConcurrentLogStreamsPerUser
 	}
+	return defaultMaxLogStreamsPerUser
+}
+
+func (s *Server) globalLogStreamLimit() int {
+	if s.MaxConcurrentLogStreamsGlobal > 0 {
+		return s.MaxConcurrentLogStreamsGlobal
+	}
+	return defaultMaxLogStreamsGlobal
+}
+
+// acquireLogStream reserves one stream slot for user. It returns false when the
+// global cap is reached or the user is already at their per-user cap. Each
+// successful acquire must be paired with releaseLogStream.
+func (s *Server) acquireLogStream(user string) bool {
 	s.logStreamMu.Lock()
 	defer s.logStreamMu.Unlock()
 	if s.logStreams == nil {
 		s.logStreams = map[string]int{}
 	}
-	if s.logStreams[user] >= s.MaxConcurrentLogStreamsPerUser {
+	// Global cap first: it bounds total memory regardless of how many distinct
+	// users are involved.
+	if s.logStreamTotal >= s.globalLogStreamLimit() {
+		return false
+	}
+	if s.logStreams[user] >= s.perUserLogStreamLimit() {
 		return false
 	}
 	s.logStreams[user]++
+	s.logStreamTotal++
 	return true
 }
 
 func (s *Server) releaseLogStream(user string) {
-	if s.MaxConcurrentLogStreamsPerUser <= 0 {
-		return
-	}
 	s.logStreamMu.Lock()
 	defer s.logStreamMu.Unlock()
 	if s.logStreams[user] > 0 {
 		s.logStreams[user]--
+		s.logStreamTotal--
 	}
 	if s.logStreams[user] == 0 {
 		delete(s.logStreams, user)
@@ -420,7 +450,7 @@ func (s *Server) StreamAppLogs(w http.ResponseWriter, r *http.Request, appID App
 		w.Header().Set("Retry-After", "5")
 		writeJSON(w, http.StatusTooManyRequests, Error{
 			Code:    "too_many_log_streams",
-			Message: fmt.Sprintf("max %d concurrent log streams per user", s.MaxConcurrentLogStreamsPerUser),
+			Message: fmt.Sprintf("too many concurrent log streams (per-user limit %d, or global capacity reached)", s.perUserLogStreamLimit()),
 		})
 		return
 	}


### PR DESCRIPTION
Works through the open **sev/low, sev/medium, and sev/high** issue backlog in one branch (per the agreed one-branch approach). Each issue is its own commit. Full `go build ./...`, `go vet ./...`, `go test ./...` (33 packages) pass; concurrency changes verified under `-race`. Every fix ships with a targeted regression test.

## Fixed with tests
**sev/low:** #66 quota label collision · #81 log-stream global cap + safe default · #79 O(1) ring buffer · #62 sampled-LRU rate-limiter eviction · #80 SQLite indexes (indexing slice)

**sev/medium:** #55 refuse no-auth on non-loopback bind (+`devInsecure`) · #74 List owner label pre-filter · #77 boundPodName field selector · #73 fuse deploy hash via TeeReader · #76 GC pagination + bounded-concurrency deletes

**sev/high:**
- **#50** rate limiting — extend coverage to `/v1/*` (deploy path was unthrottled), add a stricter per-client write-verb budget, warn when disabled on a network transport.
- **#72** ConfigMap store — lock-free reads + optimistic-concurrency (RetryOnConflict) writes; no process-wide lock held across API I/O (also fixes cross-replica lost updates).
- **#71** ConfigMap store — pre-write 900KB size guard with an actionable error instead of silently bricking at etcd's ~1MB ceiling.
- **#70** controller — capped exponential backoff for transitional requeues (was a flat 2s hot-poll → ~N/2 reconciles/sec for N stuck apps).

## Already fixed on main — closed as stale
- sev/low: #64, #65 (merged `6dcb552`)
- sev/medium: #52 (`3675da7`), #53, #56, #58, #78
- sev/high: #67 (meter on both registries), #68 (`MaxConcurrentReconciles=4`), #69 (`GenerationChangedPredicate`)

## Deferred to focused follow-ups (too large/risky for this sweep)
- **#80 remainder** — `shared_with` → indexed join table + list-API pagination (schema + data migration, interface/frontend contract change).
- **#75** quota List-then-Create TOCTOU — FIXED (moved out of deferred): reservation ledger in the enforcer closes the concurrent-overshoot race; fully cross-replica-correct bound still wants ResourceQuota/reconcile-time (follow-up).
- ConfigMap store per-object sharding (the structural half of #71) — the size guard lands now; sharding is a larger backend change and the default store backend is already `sqlite`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — 33 packages pass
- [x] GC bulk-delete + ConfigMap CRUD run under the fake clientset; GC under `-race`
- [x] `helm template` renders no-auth (`devInsecure: true`) and auth-on correctly

---
Closes #66, #79, #62, #81, #55, #74, #77, #73, #76, #50, #72, #71, #70, #75, #80. (Every open sev-labeled issue is now addressed.)