### PR TITLE
feat(authz): per-action authorizer + authenticated HTTP-route seams

### DIFF
--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -1,0 +1,134 @@
+// Package authz is the per-action authorization seam.
+//
+// The core's built-in authorization is a binary role (admin|user) plus owner
+// equality and a shared-with read list, enforced inline in the orchestrator and
+// deploy service. That is sufficient for single-user and small-team use but
+// cannot express scoped, fine-grained permissions (who may deploy/delete/
+// rollback/share/administer, per team or namespace).
+//
+// An Authorizer, when registered, REPLACES the inline owner/admin decision at
+// the artifact chokepoints: it is consulted for each action on each resource and
+// may allow access the inline check would deny (e.g. a teammate) or deny access
+// it would allow. The core installs no Authorizer, so behavior is unchanged
+// until an out-of-tree module (e.g. vibeD Enterprise's RBAC) registers one.
+package authz
+
+import (
+	"context"
+	"sync"
+)
+
+// Action identifies the operation being authorized. Values are stable strings
+// so an Authorizer (and audit records) can key on them.
+type Action string
+
+const (
+	ActionAppGet      Action = "app.get"      // read a single app
+	ActionAppList     Action = "app.list"     // list apps
+	ActionAppDeploy   Action = "app.deploy"   // create or redeploy
+	ActionAppDelete   Action = "app.delete"   // delete
+	ActionAppRollback Action = "app.rollback" // roll back to a prior version
+	ActionAppSuspend  Action = "app.suspend"  // suspend/resume
+	ActionAppShare    Action = "app.share"    // share/unshare, manage share links
+	ActionUserManage  Action = "user.manage"  // manage users/departments
+	ActionAuditRead   Action = "audit.read"   // read the audit trail
+)
+
+// Resource describes the object an action targets. For app actions it is the
+// artifact/VibedApp; ID is empty for collection actions such as list.
+type Resource struct {
+	Kind       string   // "app" (the only kind today)
+	ID         string   // artifact/app id ("" for list)
+	Owner      string   // owning user id
+	Namespace  string   // tenant/team namespace the resource lives in
+	Department string   // department label, when known (deploy path)
+	SharedWith []string // user ids granted read via sharing
+}
+
+// Request is a single authorization question: may Subject (whose core Role is
+// carried for backward-compatible admin handling) perform Action on Resource?
+type Request struct {
+	Subject  string // caller user id ("" when unauthenticated)
+	Role     string // caller's core role, e.g. "admin" | "user"
+	Action   Action
+	Resource Resource
+}
+
+// Authorizer decides a single Request. A nil return allows the action; a
+// non-nil error denies it. Implementations should return *DeniedError (or any
+// error whose Forbidden() reports true) so the API maps the denial to 403.
+type Authorizer interface {
+	Authorize(ctx context.Context, req Request) error
+}
+
+// DeniedError marks an authorization denial. The API detects it via Forbidden()
+// (mirroring policy's PolicyDenied() / quota's QuotaExceeded()) and returns 403.
+// Reason should name the missing permission for the audit record.
+type DeniedError struct {
+	Action Action
+	Reason string
+}
+
+func (e *DeniedError) Error() string {
+	if e.Reason != "" {
+		return "authorization denied: " + string(e.Action) + ": " + e.Reason
+	}
+	return "authorization denied: " + string(e.Action)
+}
+
+// Forbidden reports that this error is an authorization denial (→ HTTP 403).
+func (e *DeniedError) Forbidden() bool { return true }
+
+// IsDenied reports whether err is (or wraps) an authorization denial.
+func IsDenied(err error) bool {
+	type forbidden interface{ Forbidden() bool }
+	for err != nil {
+		if f, ok := err.(forbidden); ok && f.Forbidden() {
+			return true
+		}
+		u, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}
+
+// --- registry ---------------------------------------------------------------
+
+// Deps is what an Authorizer factory receives; Options is a generic settings bag.
+type Deps struct {
+	Options map[string]string
+}
+
+// Factory builds the process Authorizer. There is at most one.
+type Factory func(Deps) (Authorizer, error)
+
+var (
+	mu      sync.Mutex
+	factory Factory
+)
+
+// Register installs the authorizer factory. Called from an out-of-tree module's
+// init(); it panics if one is already registered.
+func Register(f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	if factory != nil {
+		panic("authz: an authorizer factory is already registered")
+	}
+	factory = f
+}
+
+// Build returns the registered Authorizer, or nil when none is registered
+// (meaning the core's built-in owner/admin checks stay in effect).
+func Build(deps Deps) (Authorizer, error) {
+	mu.Lock()
+	f := factory
+	mu.Unlock()
+	if f != nil {
+		return f(deps)
+	}
+	return nil, nil
+}

--- a/internal/deploy/authz_test.go
+++ b/internal/deploy/authz_test.go
@@ -1,0 +1,98 @@
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vibed-project/vibeD/internal/authz"
+	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
+)
+
+// stubAuthorizer is a minimal authz.Authorizer for exercising the deploy
+// service's authorization wiring: owners control their own existing apps;
+// listed "readers" may read any app; listed "writers" may write any app.
+type stubAuthorizer struct {
+	readers map[string]bool
+	writers map[string]bool
+}
+
+func (s stubAuthorizer) Authorize(_ context.Context, req authz.Request) error {
+	// Owner controls their own existing resource (deploy excluded — creation).
+	if req.Action != authz.ActionAppDeploy && req.Resource.Owner != "" && req.Resource.Owner == req.Subject {
+		return nil
+	}
+	switch req.Action {
+	case authz.ActionAppGet, authz.ActionAppList:
+		if s.readers[req.Subject] {
+			return nil
+		}
+	default:
+		if s.writers[req.Subject] {
+			return nil
+		}
+	}
+	return &authz.DeniedError{Action: req.Action, Reason: "stub deny"}
+}
+
+func appNames(apps []vibedv1.VibedApp) []string {
+	out := make([]string, len(apps))
+	for i, a := range apps {
+		out[i] = a.Name
+	}
+	return out
+}
+
+// TestListScopingWithAuthorizer covers #21: an Authorizer expands List to the
+// apps the caller may read (team-scoped visibility), replacing owner-only.
+func TestListScopingWithAuthorizer(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&vibedv1.VibedApp{}).
+		WithObjects(
+			&vibedv1.VibedApp{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "vibed-apps"}, Spec: vibedv1.VibedAppSpec{Owner: "alice"}},
+			&vibedv1.VibedApp{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "vibed-apps"}, Spec: vibedv1.VibedAppSpec{Owner: "bob"}},
+		).Build()
+	svc := newService(c, newFakeStore())
+	svc.Authz = stubAuthorizer{readers: map[string]bool{"carol": true}}
+
+	// carol is a team reader (a Viewer): sees both apps read-only.
+	if list, err := svc.List(context.Background(), "carol"); err != nil || len(list) != 2 {
+		t.Fatalf("carol List = %v (err %v), want 2", appNames(list), err)
+	}
+	// dave has no read grant and owns nothing: sees none.
+	if list, err := svc.List(context.Background(), "dave"); err != nil || len(list) != 0 {
+		t.Fatalf("dave List = %v (err %v), want 0", appNames(list), err)
+	}
+	// alice still sees her own app via ownership.
+	list, err := svc.List(context.Background(), "alice")
+	if err != nil || len(list) != 1 || list[0].Name != "a" {
+		t.Fatalf("alice List = %v (err %v), want [a]", appNames(list), err)
+	}
+}
+
+// TestWriteAuthorizationWithAuthorizer covers the read/write split: a teammate
+// who may read (Get succeeds) is still denied a write action (Delete → 403).
+func TestWriteAuthorizationWithAuthorizer(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&vibedv1.VibedApp{}).
+		WithObjects(
+			&vibedv1.VibedApp{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "vibed-apps"}, Spec: vibedv1.VibedAppSpec{Owner: "bob"}},
+		).Build()
+	svc := newService(c, newFakeStore())
+	svc.Authz = stubAuthorizer{readers: map[string]bool{"carol": true}}
+
+	// carol may read bob's app...
+	if _, err := svc.Get(context.Background(), "carol", "b"); err != nil {
+		t.Fatalf("carol Get b: want allow, got %v", err)
+	}
+	// ...but not delete it: a Forbidden authz denial.
+	if err := svc.Delete(context.Background(), "carol", "b"); !authz.IsDenied(err) {
+		t.Fatalf("carol Delete b: want denied, got %v", err)
+	}
+	// The app is still there.
+	if _, err := svc.Get(context.Background(), "bob", "b"); err != nil {
+		t.Fatalf("b should still exist: %v", err)
+	}
+}

--- a/internal/deploy/query.go
+++ b/internal/deploy/query.go
@@ -86,7 +86,17 @@ func (s *Service) List(ctx context.Context, owner string) ([]vibedv1.VibedApp, e
 		return nil, fmt.Errorf("list VibedApps: %w", err)
 	}
 	out := make([]vibedv1.VibedApp, 0, len(list.Items))
-	for _, a := range list.Items {
+	for i := range list.Items {
+		a := list.Items[i]
+		// With an Authorizer, list every app in the tenant namespace the caller
+		// may read (team-scoped visibility, e.g. a Viewer seeing team apps).
+		// Without one, keep the built-in owner-only scoping.
+		if s.Authz != nil {
+			if s.authorize(ctx, authz.ActionAppGet, &a, owner) == nil {
+				out = append(out, a)
+			}
+			continue
+		}
 		if a.Spec.Owner == owner {
 			out = append(out, a)
 		}

--- a/internal/deploy/query.go
+++ b/internal/deploy/query.go
@@ -9,6 +9,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vibed-project/vibeD/internal/audit"
+	vibedauth "github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/meter"
 	vibedv1 "github.com/vibed-project/vibeD/pkg/vibedapi/v1alpha1"
 )
@@ -35,10 +37,41 @@ func (s *Service) Get(ctx context.Context, owner, id string) (*vibedv1.VibedApp,
 	if err != nil {
 		return nil, fmt.Errorf("get VibedApp: %w", err)
 	}
+	// An Authorizer replaces the built-in owner check: it may grant a teammate
+	// read access. A denied read is reported as ErrNotFound (not 403) to avoid
+	// leaking the existence of apps the caller cannot see, matching the built-in.
+	if s.Authz != nil {
+		if aerr := s.authorize(ctx, authz.ActionAppGet, app, owner); aerr != nil {
+			return nil, ErrNotFound
+		}
+		return app, nil
+	}
 	if app.Spec.Owner != owner {
 		return nil, ErrNotFound
 	}
 	return app, nil
+}
+
+// authorize consults the registered Authorizer for action on app by owner. It
+// returns nil (allow) when no Authorizer is registered. app may be nil for
+// collection/creation actions, in which case only the identity is checked.
+func (s *Service) authorize(ctx context.Context, action authz.Action, app *vibedv1.VibedApp, owner string) error {
+	if s.Authz == nil {
+		return nil
+	}
+	res := authz.Resource{Kind: "app"}
+	if app != nil {
+		res.ID = app.Name
+		res.Owner = app.Spec.Owner
+		res.Namespace = app.Namespace
+		res.Department = app.Labels[vibedv1.LabelDepartment]
+	}
+	return s.Authz.Authorize(ctx, authz.Request{
+		Subject:  owner,
+		Role:     vibedauth.RoleFromContext(ctx),
+		Action:   action,
+		Resource: res,
+	})
 }
 
 // List returns every VibedApp owned by owner in the request's tenant namespace.
@@ -70,9 +103,13 @@ func (s *Service) SetSuspended(ctx context.Context, owner, id string, suspended 
 	if suspended {
 		action = "suspend"
 	}
-	app, err := s.Get(ctx, owner, id) // ownership-checked
+	app, err := s.Get(ctx, owner, id) // ownership-checked (read)
 	if err != nil {
 		return nil, err
+	}
+	if aerr := s.authorize(ctx, authz.ActionAppSuspend, app, owner); aerr != nil {
+		_ = s.record(ctx, action, id, "denied", aerr.Error())
+		return nil, aerr
 	}
 	if app.Spec.Suspended == suspended {
 		return app, nil // already in the desired state
@@ -99,6 +136,10 @@ func (s *Service) Delete(ctx context.Context, owner, id string) error {
 	app, err := s.Get(ctx, owner, id)
 	if err != nil {
 		return err
+	}
+	if aerr := s.authorize(ctx, authz.ActionAppDelete, app, owner); aerr != nil {
+		_ = s.record(ctx, "delete", id, "denied", aerr.Error())
+		return aerr
 	}
 	if derr := s.Client.Delete(ctx, app); derr != nil && !apierrors.IsNotFound(derr) {
 		_ = s.record(ctx, "delete", id, "error", derr.Error())

--- a/internal/deploy/service.go
+++ b/internal/deploy/service.go
@@ -23,6 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vibed-project/vibeD/internal/audit"
+	vibedauth "github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/classifier"
 	"github.com/vibed-project/vibeD/internal/meter"
 	"github.com/vibed-project/vibeD/internal/metrics"
@@ -72,6 +74,10 @@ type Service struct {
 	// Policy, when set, evaluates each deploy after classification and may deny
 	// it. nil = no policy (deploys are unrestricted).
 	Policy policy.Gate
+	// Authz, when set, authorizes each per-action access (get/deploy/delete/
+	// suspend) and replaces the built-in owner check. nil = built-in behavior
+	// (owner-or-admin, shared read).
+	Authz authz.Authorizer
 	// Meter, when set, records a usage event on each deploy/delete. nil disables
 	// metering.
 	Meter meter.Sink
@@ -232,6 +238,22 @@ func (s *Service) Deploy(ctx context.Context, req Request) (*Result, error) {
 		}); perr != nil {
 			_ = s.record(ctx, "deploy", req.Name, "denied", perr.Error())
 			return nil, perr
+		}
+	}
+
+	// Authorization: may this caller deploy into the target namespace/team?
+	// Consulted on new deploys and redeploys alike.
+	if s.Authz != nil {
+		if aerr := s.Authz.Authorize(ctx, authz.Request{
+			Subject: req.Owner,
+			Role:    vibedauth.RoleFromContext(ctx),
+			Action:  authz.ActionAppDeploy,
+			Resource: authz.Resource{
+				Kind: "app", ID: req.Name, Owner: req.Owner, Namespace: t.Namespace,
+			},
+		}); aerr != nil {
+			_ = s.record(ctx, "deploy", req.Name, "denied", aerr.Error())
+			return nil, aerr
 		}
 	}
 

--- a/internal/httproutes/httproutes.go
+++ b/internal/httproutes/httproutes.go
@@ -1,0 +1,60 @@
+// Package httproutes is the seam for out-of-tree modules to contribute
+// additional HTTP routes to the control-plane server.
+//
+// Unlike the auth package's login Routes (which are public, for SSO callbacks),
+// routes registered here are mounted on the main mux and therefore run behind
+// the authentication + role middleware — the caller's identity and role are in
+// the request context, so a handler can enforce its own RBAC. The core
+// registers none; an enterprise module uses this to expose, e.g., a
+// role-management API. Multiple modules may register.
+package httproutes
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Route is an authenticated HTTP route (a Go 1.22 pattern + handler) mounted on
+// the control-plane mux.
+type Route struct {
+	Pattern string // e.g. "POST /v1/rolebindings"
+	Handler http.Handler
+}
+
+// Deps is what a route factory receives; Options is a generic settings bag.
+type Deps struct {
+	Options map[string]string
+}
+
+// Factory builds a module's routes. Multiple may be registered.
+type Factory func(Deps) ([]Route, error)
+
+var (
+	mu        sync.Mutex
+	factories []Factory
+)
+
+// Register adds a route factory. Called from an out-of-tree module's init().
+func Register(f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	factories = append(factories, f)
+}
+
+// Build invokes every registered factory and returns the combined routes. The
+// core registers none, so this is empty unless a module contributes.
+func Build(deps Deps) ([]Route, error) {
+	mu.Lock()
+	fs := append([]Factory(nil), factories...)
+	mu.Unlock()
+
+	var routes []Route
+	for _, f := range fs {
+		rs, err := f(deps)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, rs...)
+	}
+	return routes, nil
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/vibed-project/vibeD/internal/appspec"
 	vibedauth "github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/config"
 	"github.com/vibed-project/vibeD/internal/deployer"
 	"github.com/vibed-project/vibeD/internal/environment"
@@ -85,6 +86,10 @@ type Orchestrator struct {
 	shareLinkStore store.ShareLinkStore
 	tracer         trace.Tracer
 	logger         *slog.Logger
+
+	// authorizer, when set, replaces the built-in owner/admin/shared checks with
+	// per-action RBAC (see checkOwnership/checkWriteOwnership). nil = built-in.
+	authorizer authz.Authorizer
 
 	// lifeCtx is cancelled on orchestrator Shutdown — async goroutines derive
 	// their context from this so SIGTERM unblocks in-flight deploys instead of
@@ -421,7 +426,7 @@ func (o *Orchestrator) AsyncUpdate(ctx context.Context, req UpdateRequest) (*Dep
 	if err != nil {
 		return nil, err
 	}
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppDeploy); err != nil {
 		return nil, err
 	}
 
@@ -494,7 +499,7 @@ func (o *Orchestrator) doUpdate(ctx context.Context, req UpdateRequest) (*Deploy
 		return nil, err
 	}
 
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppDeploy); err != nil {
 		return nil, err
 	}
 
@@ -565,7 +570,7 @@ func (o *Orchestrator) Delete(ctx context.Context, artifactID string) error {
 		return err
 	}
 
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppDelete); err != nil {
 		o.metrics.DeletesTotal.WithLabelValues("failed").Inc()
 		return err
 	}
@@ -621,7 +626,7 @@ func (o *Orchestrator) Status(ctx context.Context, artifactID string) (*api.Arti
 	if err != nil {
 		return nil, err
 	}
-	if err := o.checkOwnership(ctx, artifact); err != nil {
+	if err := o.checkOwnership(ctx, artifact, authz.ActionAppGet); err != nil {
 		return nil, err
 	}
 	return artifact, nil
@@ -654,7 +659,7 @@ func (o *Orchestrator) Logs(ctx context.Context, artifactID string, lines int) (
 		return nil, err
 	}
 
-	if err := o.checkOwnership(ctx, artifact); err != nil {
+	if err := o.checkOwnership(ctx, artifact, authz.ActionAppGet); err != nil {
 		return nil, err
 	}
 
@@ -684,18 +689,42 @@ func (o *Orchestrator) authEnabled() bool {
 	return o.cfg != nil && o.cfg.Auth.Enabled
 }
 
-// checkOwnership verifies that the current user can read the artifact.
-// Allows: owner, admin, or users in the SharedWith list.
+// SetAuthorizer installs a per-action authorizer that replaces the built-in
+// owner/admin/shared checks. Called once at startup; nil keeps the built-ins.
+func (o *Orchestrator) SetAuthorizer(a authz.Authorizer) { o.authorizer = a }
+
+// artifactResource maps a legacy artifact to the authorizer's resource shape.
+func artifactResource(a *api.Artifact) authz.Resource {
+	return authz.Resource{
+		Kind: "app", ID: a.ID, Owner: a.OwnerID,
+		Namespace: a.Namespace, SharedWith: a.SharedWith,
+	}
+}
+
+// checkOwnership verifies that the current user can read the artifact under the
+// given read action. Allows: owner, admin, or users in the SharedWith list —
+// or, when an authorizer is installed, whatever it permits.
 // Returns ErrNotFound (not Forbidden) to avoid leaking artifact existence to non-owners.
 // With auth disabled all checks pass (dev/no-auth); with auth enabled a caller
 // with no identity is denied.
-func (o *Orchestrator) checkOwnership(ctx context.Context, artifact *api.Artifact) error {
+func (o *Orchestrator) checkOwnership(ctx context.Context, artifact *api.Artifact, action authz.Action) error {
 	if !o.authEnabled() {
 		return nil // Auth disabled — no ownership enforcement
 	}
 	ownerID := vibedauth.UserIDFromContext(ctx)
 	if ownerID == "" {
 		return &api.ErrNotFound{ArtifactID: artifact.ID} // auth on, no identity → fail closed
+	}
+	if o.authorizer != nil {
+		// A denial is reported as ErrNotFound (not Forbidden) to preserve this
+		// path's existence-hiding convention; the authorizer still records it.
+		if err := o.authorizer.Authorize(ctx, authz.Request{
+			Subject: ownerID, Role: vibedauth.RoleFromContext(ctx),
+			Action: action, Resource: artifactResource(artifact),
+		}); err != nil {
+			return &api.ErrNotFound{ArtifactID: artifact.ID}
+		}
+		return nil
 	}
 	if vibedauth.IsAdmin(ctx) {
 		return nil // Admin can access everything
@@ -712,15 +741,25 @@ func (o *Orchestrator) checkOwnership(ctx context.Context, artifact *api.Artifac
 	return &api.ErrNotFound{ArtifactID: artifact.ID}
 }
 
-// checkWriteOwnership verifies that the current user can modify the artifact.
-// Only owner and admin can write — shared users have read-only access.
-func (o *Orchestrator) checkWriteOwnership(ctx context.Context, artifact *api.Artifact) error {
+// checkWriteOwnership verifies that the current user can perform the given write
+// action on the artifact. Only owner and admin can write — shared users have
+// read-only access — or, when an authorizer is installed, whatever it permits.
+func (o *Orchestrator) checkWriteOwnership(ctx context.Context, artifact *api.Artifact, action authz.Action) error {
 	if !o.authEnabled() {
 		return nil // Auth disabled
 	}
 	ownerID := vibedauth.UserIDFromContext(ctx)
 	if ownerID == "" {
 		return &api.ErrNotFound{ArtifactID: artifact.ID} // auth on, no identity → fail closed
+	}
+	if o.authorizer != nil {
+		if err := o.authorizer.Authorize(ctx, authz.Request{
+			Subject: ownerID, Role: vibedauth.RoleFromContext(ctx),
+			Action: action, Resource: artifactResource(artifact),
+		}); err != nil {
+			return &api.ErrNotFound{ArtifactID: artifact.ID}
+		}
+		return nil
 	}
 	if vibedauth.IsAdmin(ctx) {
 		return nil // Admin can modify everything
@@ -1163,7 +1202,7 @@ func (o *Orchestrator) ListVersions(ctx context.Context, artifactID string) ([]a
 	if err != nil {
 		return nil, err
 	}
-	if err := o.checkOwnership(ctx, artifact); err != nil {
+	if err := o.checkOwnership(ctx, artifact, authz.ActionAppGet); err != nil {
 		return nil, err
 	}
 	return o.store.ListVersions(ctx, artifactID)
@@ -1184,7 +1223,7 @@ func (o *Orchestrator) Rollback(ctx context.Context, artifactID string, targetVe
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppRollback); err != nil {
 		return nil, err
 	}
 
@@ -1253,7 +1292,7 @@ func (o *Orchestrator) ShareArtifact(ctx context.Context, artifactID string, use
 	if err != nil {
 		return err
 	}
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppShare); err != nil {
 		return err
 	}
 
@@ -1281,7 +1320,7 @@ func (o *Orchestrator) UnshareArtifact(ctx context.Context, artifactID string, u
 	if err != nil {
 		return err
 	}
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppShare); err != nil {
 		return err
 	}
 
@@ -1316,7 +1355,7 @@ func (o *Orchestrator) CreateShareLink(ctx context.Context, artifactID, password
 	if err != nil {
 		return nil, err
 	}
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppShare); err != nil {
 		return nil, err
 	}
 
@@ -1370,7 +1409,7 @@ func (o *Orchestrator) ListShareLinks(ctx context.Context, artifactID string) ([
 	if err != nil {
 		return nil, err
 	}
-	if err := o.checkOwnership(ctx, artifact); err != nil {
+	if err := o.checkOwnership(ctx, artifact, authz.ActionAppGet); err != nil {
 		return nil, err
 	}
 	links, err := o.shareLinkStore.ListShareLinks(ctx, artifactID)
@@ -1399,7 +1438,7 @@ func (o *Orchestrator) RevokeShareLink(ctx context.Context, token string) error 
 	if err != nil {
 		return err
 	}
-	if err := o.checkWriteOwnership(ctx, artifact); err != nil {
+	if err := o.checkWriteOwnership(ctx, artifact, authz.ActionAppShare); err != nil {
 		return err
 	}
 	return o.shareLinkStore.RevokeShareLink(ctx, token)

--- a/internal/orchestrator/ownership_test.go
+++ b/internal/orchestrator/ownership_test.go
@@ -2,12 +2,24 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	vibedauth "github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/config"
 	"github.com/vibed-project/vibeD/pkg/api"
 )
+
+// stubAuthz allows exactly the actions in its set.
+type stubAuthz struct{ allow map[authz.Action]bool }
+
+func (s stubAuthz) Authorize(_ context.Context, req authz.Request) error {
+	if s.allow[req.Action] {
+		return nil
+	}
+	return &authz.DeniedError{Action: req.Action, Reason: "stub"}
+}
 
 func orchWithAuth(enabled bool) *Orchestrator {
 	return &Orchestrator{cfg: &config.Config{Auth: config.AuthConfig{Enabled: enabled}}}
@@ -30,7 +42,7 @@ func TestCheckOwnership_FailsClosedWhenAuthEnabled(t *testing.T) {
 	art := &api.Artifact{ID: "app-1", OwnerID: "alice", SharedWith: []string{"carol"}}
 
 	// Auth disabled → no enforcement (dev/no-auth mode).
-	if err := orchWithAuth(false).checkOwnership(context.Background(), art); err != nil {
+	if err := orchWithAuth(false).checkOwnership(context.Background(), art, authz.ActionAppGet); err != nil {
 		t.Errorf("auth disabled: want allow, got %v", err)
 	}
 
@@ -47,7 +59,7 @@ func TestCheckOwnership_FailsClosedWhenAuthEnabled(t *testing.T) {
 		{"admin allowed", ctxAdmin("someadmin"), true},
 	}
 	for _, c := range cases {
-		err := on.checkOwnership(c.ctx, art)
+		err := on.checkOwnership(c.ctx, art, authz.ActionAppGet)
 		if c.allowed && err != nil {
 			t.Errorf("%s: want allow, got %v", c.name, err)
 		}
@@ -73,7 +85,7 @@ func TestCheckWriteOwnership_FailsClosedWhenAuthEnabled(t *testing.T) {
 		{"admin allowed", ctxAdmin("someadmin"), true},
 	}
 	for _, c := range cases {
-		err := on.checkWriteOwnership(c.ctx, art)
+		err := on.checkWriteOwnership(c.ctx, art, authz.ActionAppDelete)
 		if c.allowed && err != nil {
 			t.Errorf("%s: want allow, got %v", c.name, err)
 		}
@@ -83,12 +95,36 @@ func TestCheckWriteOwnership_FailsClosedWhenAuthEnabled(t *testing.T) {
 	}
 
 	// Auth disabled → allow even anonymously.
-	if err := orchWithAuth(false).checkWriteOwnership(context.Background(), art); err != nil {
+	if err := orchWithAuth(false).checkWriteOwnership(context.Background(), art, authz.ActionAppDelete); err != nil {
 		t.Errorf("auth disabled: want allow, got %v", err)
 	}
 	// Unowned artifact + authenticated user → writable.
 	unowned := &api.Artifact{ID: "app-2", OwnerID: ""}
-	if err := on.checkWriteOwnership(ctxUser("alice"), unowned); err != nil {
+	if err := on.checkWriteOwnership(ctxUser("alice"), unowned, authz.ActionAppDelete); err != nil {
 		t.Errorf("unowned artifact: want allow for authed user, got %v", err)
+	}
+}
+
+// TestCheckOwnership_UsesAuthorizerWhenSet verifies the installed authorizer
+// replaces the built-in owner check on the legacy path: a non-owner is allowed
+// a read the authorizer permits, and a denied write is reported as ErrNotFound
+// (this path hides existence rather than returning 403).
+func TestCheckOwnership_UsesAuthorizerWhenSet(t *testing.T) {
+	art := &api.Artifact{ID: "app-1", OwnerID: "alice"}
+	on := orchWithAuth(true)
+	on.authorizer = stubAuthz{allow: map[authz.Action]bool{authz.ActionAppGet: true}}
+
+	// Non-owner bob may read (authorizer grants app.get).
+	if err := on.checkOwnership(ctxUser("bob"), art, authz.ActionAppGet); err != nil {
+		t.Errorf("authorizer-allowed read: want allow, got %v", err)
+	}
+	// bob may not delete (authorizer denies app.delete) → ErrNotFound.
+	err := on.checkWriteOwnership(ctxUser("bob"), art, authz.ActionAppDelete)
+	if err == nil {
+		t.Fatal("authorizer-denied write: want deny, got allow")
+	}
+	var nf *api.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("want ErrNotFound on denied legacy write, got %T (%v)", err, err)
 	}
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -26,12 +26,15 @@
 package plugin
 
 import (
+	"context"
+
 	mcpauth "github.com/modelcontextprotocol/go-sdk/auth"
 
 	"github.com/vibed-project/vibeD/internal/auth"
 	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/config"
 	"github.com/vibed-project/vibeD/internal/entitlements"
+	"github.com/vibed-project/vibeD/internal/httproutes"
 	"github.com/vibed-project/vibeD/internal/meter"
 	"github.com/vibed-project/vibeD/internal/policy"
 	"github.com/vibed-project/vibeD/internal/store"
@@ -194,6 +197,35 @@ const (
 // core installs none, so the built-in owner/admin checks stay in effect until
 // one is registered.
 func RegisterAuthorizer(f func(AuthzDeps) (Authorizer, error)) { authz.Register(f) }
+
+// --- Additional HTTP routes ------------------------------------------------
+
+// HTTPRoute is an authenticated route a module contributes to the control-plane
+// mux (behind the auth+role middleware, so the caller identity/role is in the
+// request context). HTTPRouteDeps is what a route factory receives.
+type (
+	HTTPRoute     = httproutes.Route
+	HTTPRouteDeps = httproutes.Deps
+)
+
+// RegisterHTTPRoutes adds a factory contributing authenticated HTTP routes
+// (e.g. an enterprise role-management API). Multiple modules may register; the
+// core registers none.
+func RegisterHTTPRoutes(f func(HTTPRouteDeps) ([]HTTPRoute, error)) { httproutes.Register(f) }
+
+// Request-identity readers for module HTTP handlers mounted via
+// RegisterHTTPRoutes (which run behind the auth+role middleware). UserIDFrom
+// Context returns the caller's user id ("" if unauthenticated); RoleFromContext
+// returns the caller's core role (defaults to "user").
+func UserIDFromContext(ctx context.Context) string { return auth.UserIDFromContext(ctx) }
+func RoleFromContext(ctx context.Context) string   { return auth.RoleFromContext(ctx) }
+
+// ContextWithIdentity returns ctx carrying the given user id and role. The
+// server's middleware sets these on live requests; a module uses this in its own
+// middleware or tests to construct an authenticated context.
+func ContextWithIdentity(ctx context.Context, userID, role string) context.Context {
+	return auth.WithRole(auth.WithUserID(ctx, userID), role)
+}
 
 // --- Metering (usage) ------------------------------------------------------
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -29,6 +29,7 @@ import (
 	mcpauth "github.com/modelcontextprotocol/go-sdk/auth"
 
 	"github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/config"
 	"github.com/vibed-project/vibeD/internal/entitlements"
 	"github.com/vibed-project/vibeD/internal/meter"
@@ -158,6 +159,41 @@ type (
 // RegisterPolicyGate installs the process policy gate factory (at most one). The
 // core installs no gate, so deploys are unrestricted until one is registered.
 func RegisterPolicyGate(f func(PolicyDeps) (PolicyGate, error)) { policy.Register(f) }
+
+// --- Authorization (per-action RBAC) ---------------------------------------
+
+// Authorizer decides a single AuthzRequest — may a subject perform an action on
+// a resource. When registered it replaces the core's built-in owner/admin check
+// at the artifact chokepoints, so it can grant scoped access (e.g. a teammate)
+// or deny access the owner check would allow. AuthzResource/AuthzAction describe
+// the target; AuthzDeniedError (or any error whose Forbidden() is true) makes
+// the API return 403. AuthzDeps is what an authorizer factory receives.
+type (
+	Authorizer       = authz.Authorizer
+	AuthzRequest     = authz.Request
+	AuthzResource    = authz.Resource
+	AuthzAction      = authz.Action
+	AuthzDeniedError = authz.DeniedError
+	AuthzDeps        = authz.Deps
+)
+
+// Authz action constants, re-exported for out-of-tree authorizers.
+const (
+	AuthzAppGet      = authz.ActionAppGet
+	AuthzAppList     = authz.ActionAppList
+	AuthzAppDeploy   = authz.ActionAppDeploy
+	AuthzAppDelete   = authz.ActionAppDelete
+	AuthzAppRollback = authz.ActionAppRollback
+	AuthzAppSuspend  = authz.ActionAppSuspend
+	AuthzAppShare    = authz.ActionAppShare
+	AuthzUserManage  = authz.ActionUserManage
+	AuthzAuditRead   = authz.ActionAuditRead
+)
+
+// RegisterAuthorizer installs the process authorizer factory (at most one). The
+// core installs none, so the built-in owner/admin checks stay in effect until
+// one is registered.
+func RegisterAuthorizer(f func(AuthzDeps) (Authorizer, error)) { authz.Register(f) }
 
 // --- Metering (usage) ------------------------------------------------------
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vibed-project/vibeD/internal/audit"
 	vibedauth "github.com/vibed-project/vibeD/internal/auth"
+	"github.com/vibed-project/vibeD/internal/authz"
 	"github.com/vibed-project/vibeD/internal/classifier"
 	"github.com/vibed-project/vibeD/internal/config"
 	"github.com/vibed-project/vibeD/internal/deploy"
@@ -338,6 +339,18 @@ func Run(cfg *config.Config, logger *slog.Logger) {
 			os.Exit(1)
 		}
 		deploySvc.Policy = gate
+
+		// Per-action authorizer (none by default → built-in owner/admin checks).
+		// An out-of-tree module may register RBAC.
+		az, aerr := authz.Build(authz.Deps{})
+		if aerr != nil {
+			logger.Error("failed to build authorizer", "error", aerr)
+			os.Exit(1)
+		}
+		deploySvc.Authz = az
+		if az != nil {
+			logger.Info("per-action authorizer enabled")
+		}
 
 		sink, merr := meter.Build(meter.Deps{})
 		if merr != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vibed-project/vibeD/internal/frontend"
 	"github.com/vibed-project/vibeD/internal/gc"
 	"github.com/vibed-project/vibeD/internal/health"
+	"github.com/vibed-project/vibeD/internal/httproutes"
 	"github.com/vibed-project/vibeD/internal/k8s"
 	mcppkg "github.com/vibed-project/vibeD/internal/mcp"
 	"github.com/vibed-project/vibeD/internal/meter"
@@ -454,6 +455,19 @@ func runHTTPServer(ctx context.Context, cfg *config.Config, mcpServer *mcp.Serve
 	// surface, so it's mounted directly; SkipAuthPaths still authenticates
 	// /v1/* and the handler enforces the admin role.
 	mux.HandleFunc("GET /v1/audit", auditHandler(auditRec, logger))
+
+	// Additional routes contributed by out-of-tree modules (e.g. an enterprise
+	// role-management API). Mounted on the mux, so they run behind the auth+role
+	// middleware; each handler enforces its own RBAC. The core registers none.
+	if extraRoutes, rerr := httproutes.Build(httproutes.Deps{}); rerr != nil {
+		logger.Error("failed to build module HTTP routes", "error", rerr)
+		os.Exit(1)
+	} else {
+		for _, rt := range extraRoutes {
+			mux.Handle(rt.Pattern, rt.Handler)
+			logger.Info("mounted module route", "pattern", rt.Pattern)
+		}
+	}
 
 	// MCP HTTP endpoint
 	mcpHandler := mcp.NewStreamableHTTPHandler(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -279,6 +279,19 @@ func Run(cfg *config.Config, logger *slog.Logger) {
 
 	orch := orchestrator.NewOrchestrator(cfg, detector, factory, stg, st, userStore, m, k8sClients.Clientset, bus, shareLinkStore, logger)
 
+	// Per-action authorizer (none by default → built-in owner/admin checks). An
+	// out-of-tree module may register RBAC; it applies to both the orchestrator
+	// (legacy /api/artifacts) and the deploy service (/v1) paths.
+	authorizer, aerr := authz.Build(authz.Deps{})
+	if aerr != nil {
+		logger.Error("failed to build authorizer", "error", aerr)
+		os.Exit(1)
+	}
+	orch.SetAuthorizer(authorizer)
+	if authorizer != nil {
+		logger.Info("per-action authorizer enabled")
+	}
+
 	// Lifecycle context shared by GC and orchestrator's async goroutines so
 	// SIGTERM cancels in-flight builds and the GC loop together.
 	lifeCtx, lifeCancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -341,17 +354,8 @@ func Run(cfg *config.Config, logger *slog.Logger) {
 		}
 		deploySvc.Policy = gate
 
-		// Per-action authorizer (none by default → built-in owner/admin checks).
-		// An out-of-tree module may register RBAC.
-		az, aerr := authz.Build(authz.Deps{})
-		if aerr != nil {
-			logger.Error("failed to build authorizer", "error", aerr)
-			os.Exit(1)
-		}
-		deploySvc.Authz = az
-		if az != nil {
-			logger.Info("per-action authorizer enabled")
-		}
+		// Same authorizer instance that gates the orchestrator path (built above).
+		deploySvc.Authz = authorizer
 
 		sink, merr := meter.Build(meter.Deps{})
 		if merr != nil {

--- a/pkg/vibedapi/http/server.go
+++ b/pkg/vibedapi/http/server.go
@@ -207,6 +207,10 @@ func (s *Server) runDeploy(w http.ResponseWriter, r *http.Request, owner, forced
 
 	res, err := s.Deploy.Deploy(r.Context(), req)
 	if err != nil {
+		if forbidden(err) {
+			writeJSON(w, http.StatusForbidden, Error{Code: "forbidden", Message: err.Error()})
+			return
+		}
 		var pe interface{ PolicyDenied() bool }
 		if errors.As(err, &pe) {
 			writeJSON(w, http.StatusForbidden, Error{Code: "policy_denied", Message: err.Error()})
@@ -291,6 +295,10 @@ func (s *Server) DeleteApp(w http.ResponseWriter, r *http.Request, appID AppID) 
 	err := s.Deploy.Delete(r.Context(), owner, appID)
 	if errors.Is(err, deploy.ErrNotFound) {
 		writeJSON(w, http.StatusNotFound, Error{Code: "not_found", Message: "app not found"})
+		return
+	}
+	if forbidden(err) {
+		writeJSON(w, http.StatusForbidden, Error{Code: "forbidden", Message: err.Error()})
 		return
 	}
 	if err != nil {
@@ -385,6 +393,10 @@ func (s *Server) setSuspended(w http.ResponseWriter, r *http.Request, appID AppI
 	if err != nil {
 		if errors.Is(err, deploy.ErrNotFound) {
 			writeJSON(w, http.StatusNotFound, Error{Code: "not_found", Message: "app not found"})
+			return
+		}
+		if forbidden(err) {
+			writeJSON(w, http.StatusForbidden, Error{Code: "forbidden", Message: err.Error()})
 			return
 		}
 		writeJSON(w, http.StatusInternalServerError, Error{Code: "suspend_failed", Message: err.Error()})
@@ -546,6 +558,14 @@ func notImplemented(w http.ResponseWriter, code, message string) {
 		Code:    code + "_not_implemented",
 		Message: message,
 	})
+}
+
+// forbidden reports whether err is (or wraps) an authorization denial — any
+// error whose Forbidden() method returns true (e.g. authz.DeniedError) — so the
+// handler can map it to HTTP 403.
+func forbidden(err error) bool {
+	var fe interface{ Forbidden() bool }
+	return errors.As(err, &fe) && fe.Forbidden()
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {


### PR DESCRIPTION
## Summary
Adds two provider-agnostic extension seams to the core so an out-of-tree module can enforce fine-grained, scoped RBAC in place of the built-in binary owner/admin check. Mirrors the existing `RegisterPolicyGate`/`RegisterTenantResolver` pattern. The core installs neither, so default behavior is unchanged.

- **`RegisterAuthorizer`** (`internal/authz` + `pkg/plugin`): an `Authorizer.Authorize(ctx, req)` seam. When registered it replaces the owner check at **both** the `/v1` `deploy.Service` path (`Get`/`Deploy`/`Delete`/`SetSuspended`, plus team-scoped `List`) **and** the legacy `orchestrator` path (`checkOwnership`/`checkWriteOwnership`, threaded per action across all call sites). Read denials read as `ErrNotFound` (no existence leak); `/v1` write denials return 403 via any `Forbidden()` error.
- **`RegisterHTTPRoutes`** (`internal/httproutes` + `pkg/plugin`): contribute *authenticated* HTTP routes mounted behind the auth+role middleware (for an enterprise role-management API). Plus `UserIDFromContext`/`RoleFromContext`/`ContextWithIdentity` exports so module handlers can read/set caller identity.

## Scope / status
Prototype validated end-to-end against a downstream RBAC implementation via a local `go.work`. **Draft** — opening for review of the seam shapes before a tagged release. Remaining follow-up: the legacy `List` is still owner/admin-scoped (team-scoped `List` is wired on `/v1`).

## Testing
Full core suite green, including `internal/authz`, `internal/orchestrator`, `internal/deploy`, `internal/httproutes`, `pkg/vibedapi/http`, `pkg/plugin`, `pkg/server`, and the e2e/controller suites. Existing ownership/deploy/http tests unchanged (no authorizer → old semantics); new tests cover the authorizer on both paths, list scoping, and the read/write split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)