### PR TITLE
feat: Public HTTP routes + OIDC provisioning hardening

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -106,8 +107,40 @@ func NoAuthAdminMiddleware() func(http.Handler) http.Handler {
 	}
 }
 
+// publicPrefixes holds path prefixes a module registered as exempt from the
+// user-auth middleware (it authenticates them itself, e.g. a SCIM token). Guarded
+// because RegisterPublicPrefix runs at wiring time from the server goroutine.
+var (
+	publicMu       sync.Mutex
+	publicPrefixes []string
+)
+
+// RegisterPublicPrefix marks a path prefix as exempt from the core user-auth
+// middleware. The server calls it when mounting a module's Public route; the
+// module's handler then enforces its own authentication.
+func RegisterPublicPrefix(prefix string) {
+	if prefix == "" {
+		return
+	}
+	publicMu.Lock()
+	defer publicMu.Unlock()
+	publicPrefixes = append(publicPrefixes, prefix)
+}
+
+func isRegisteredPublic(path string) bool {
+	publicMu.Lock()
+	defer publicMu.Unlock()
+	for _, p := range publicPrefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // SkipAuthPaths wraps an auth middleware to skip authentication for certain paths
-// (health checks, metrics, static frontend assets).
+// (health checks, metrics, static frontend assets, and module-registered public
+// prefixes).
 func SkipAuthPaths(authMiddleware func(http.Handler) http.Handler) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		authed := authMiddleware(next)
@@ -118,6 +151,13 @@ func SkipAuthPaths(authMiddleware func(http.Handler) http.Handler) func(http.Han
 				strings.HasPrefix(path, "/api/docs") ||
 				strings.HasPrefix(path, "/api/share/") ||
 				strings.HasPrefix(path, "/.well-known/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Module-registered public prefixes (e.g. /scim/v2/) — checked before
+			// the protected block so a module can self-authenticate a route that
+			// would otherwise fall under a protected prefix.
+			if isRegisteredPublic(path) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -498,49 +498,14 @@ func newOIDCVerifier(cfg config.OIDCConfig, userStore store.UserStore, logger *s
 			}
 		}
 
-		// Auto-provision user if store is available
+		// Provision / re-sync the user (parity with SAML: cross-provider bind
+		// guard + role/email/department sync on every login). A refused bind
+		// (the sub collides with a non-OIDC account) rejects the token.
 		if userStore != nil {
-			if _, err := userStore.GetUser(ctx, sub); err != nil {
-				// Resolve department from claim
-				var deptID string
-				if cfg.DepartmentClaim != "" {
-					deptName := extractStringClaim(claims, cfg.DepartmentClaim)
-					if deptName != "" {
-						dept, dErr := userStore.GetDepartmentByName(ctx, deptName)
-						if dErr != nil {
-							now := time.Now()
-							dept = &api.Department{
-								ID: fmt.Sprintf("dept-%x", now.UnixNano()), Name: deptName,
-								CreatedAt: now, UpdatedAt: now,
-							}
-							if cErr := userStore.CreateDepartment(ctx, dept); cErr != nil {
-								dept, _ = userStore.GetDepartmentByName(ctx, deptName)
-							}
-						}
-						if dept != nil {
-							deptID = dept.ID
-						}
-					}
-				}
-
-				// User doesn't exist — create
-				now := time.Now()
-				newUser := &api.User{
-					ID:           sub,
-					Name:         username,
-					Email:        email,
-					Role:         role,
-					Status:       "active",
-					Provider:     "oidc",
-					DepartmentID: deptID,
-					CreatedAt:    now,
-					UpdatedAt:    now,
-				}
-				if createErr := userStore.CreateUser(ctx, newUser); createErr != nil {
-					logger.Debug("auto-provision user failed (may already exist)", "sub", sub, "error", createErr)
-				} else {
-					logger.Info("auto-provisioned OIDC user", "sub", sub, "name", username, "role", role, "department", deptID)
-				}
+			deptID := resolveOIDCDepartment(ctx, userStore, cfg.DepartmentClaim, claims, logger)
+			if err := syncOIDCUser(ctx, userStore, sub, username, email, role, deptID, logger); err != nil {
+				logger.Warn("OIDC: bind refused", "sub", sub, "error", err)
+				return nil, mcpauth.ErrInvalidToken
 			}
 		}
 
@@ -551,6 +516,97 @@ func newOIDCVerifier(cfg config.OIDCConfig, userStore store.UserStore, logger *s
 			Expiration: idToken.Expiry,
 		}, nil
 	}, nil
+}
+
+// syncOIDCUser provisions a new OIDC user or re-syncs an existing one. It
+// returns an error when sub already belongs to a non-OIDC account (cross-
+// provider bind refused), so the verifier can reject the token — mirroring the
+// SAML provider's guard. Re-sync updates role/email/department on each login.
+func syncOIDCUser(ctx context.Context, userStore store.UserStore, sub, username, email, role, deptID string, logger *slog.Logger) error {
+	if existing, err := userStore.GetUser(ctx, sub); err == nil && existing != nil {
+		if existing.Provider != "oidc" {
+			return fmt.Errorf("refusing to bind to %s account %q", existing.Provider, sub)
+		}
+		changed := false
+		if existing.Role != role {
+			existing.Role = role
+			changed = true
+		}
+		if email != "" && existing.Email != email {
+			existing.Email = email
+			changed = true
+		}
+		if deptID != "" && existing.DepartmentID != deptID {
+			existing.DepartmentID = deptID
+			changed = true
+		}
+		if changed {
+			existing.UpdatedAt = time.Now()
+			if err := userStore.UpdateUser(ctx, existing); err != nil {
+				logger.Warn("OIDC: user re-sync failed", "sub", sub, "error", err)
+			}
+		}
+		return nil
+	}
+	now := time.Now()
+	u := &api.User{
+		ID: sub, Name: username, Email: email, Role: role,
+		Status: "active", Provider: "oidc", DepartmentID: deptID,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := userStore.CreateUser(ctx, u); err != nil {
+		// A lost create race is fine (the row now exists); only log.
+		logger.Debug("OIDC auto-provision (may already exist)", "sub", sub, "error", err)
+	} else {
+		logger.Info("auto-provisioned OIDC user", "sub", sub, "name", username, "role", role, "department", deptID)
+	}
+	return nil
+}
+
+// resolveOIDCDepartment get-or-creates the department named by departmentClaim
+// and returns its id ("" when unset). The id is a deterministic dept-<slug> (as
+// SAML does), so concurrent replicas converge on one row instead of the previous
+// non-deterministic dept-<nanos> that could create duplicates.
+func resolveOIDCDepartment(ctx context.Context, userStore store.UserStore, departmentClaim string, claims map[string]interface{}, logger *slog.Logger) string {
+	if departmentClaim == "" {
+		return ""
+	}
+	name := extractStringClaim(claims, departmentClaim)
+	if name == "" {
+		return ""
+	}
+	if dept, err := userStore.GetDepartmentByName(ctx, name); err == nil && dept != nil {
+		return dept.ID
+	}
+	now := time.Now()
+	dept := &api.Department{ID: "dept-" + slugify(name), Name: name, CreatedAt: now, UpdatedAt: now}
+	if err := userStore.CreateDepartment(ctx, dept); err != nil {
+		if existing, e := userStore.GetDepartmentByName(ctx, name); e == nil && existing != nil {
+			return existing.ID
+		}
+		logger.Warn("OIDC: resolving department", "name", name, "error", err)
+		return ""
+	}
+	return dept.ID
+}
+
+// slugify lowercases s and keeps only [a-z0-9-], collapsing other runs to '-'.
+func slugify(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // extractStringClaim extracts a string value from a claims map.

--- a/internal/auth/oidc_provision_test.go
+++ b/internal/auth/oidc_provision_test.go
@@ -1,0 +1,152 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/vibed-project/vibeD/pkg/api"
+)
+
+// oidcFakeStore is a minimal UserStore for the OIDC provisioning/re-sync tests.
+type oidcFakeStore struct {
+	users map[string]*api.User
+	depts map[string]*api.Department // by name
+}
+
+func newOIDCFakeStore() *oidcFakeStore {
+	return &oidcFakeStore{users: map[string]*api.User{}, depts: map[string]*api.Department{}}
+}
+
+func (f *oidcFakeStore) GetUser(_ context.Context, id string) (*api.User, error) {
+	if u, ok := f.users[id]; ok {
+		cp := *u
+		return &cp, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+func (f *oidcFakeStore) CreateUser(_ context.Context, u *api.User) error {
+	if _, ok := f.users[u.ID]; ok {
+		return fmt.Errorf("exists")
+	}
+	cp := *u
+	f.users[u.ID] = &cp
+	return nil
+}
+func (f *oidcFakeStore) UpdateUser(_ context.Context, u *api.User) error {
+	cp := *u
+	f.users[u.ID] = &cp
+	return nil
+}
+func (f *oidcFakeStore) CreateDepartment(_ context.Context, d *api.Department) error {
+	if _, ok := f.depts[d.Name]; ok {
+		return fmt.Errorf("exists")
+	}
+	cp := *d
+	f.depts[d.Name] = &cp
+	return nil
+}
+func (f *oidcFakeStore) GetDepartmentByName(_ context.Context, name string) (*api.Department, error) {
+	if d, ok := f.depts[name]; ok {
+		cp := *d
+		return &cp, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+// Unused UserStore methods.
+func (f *oidcFakeStore) GetUserByName(context.Context, string) (*api.User, error) {
+	return nil, fmt.Errorf("n/a")
+}
+func (f *oidcFakeStore) GetUserByAPIKeyHash(context.Context, string) (*api.User, error) {
+	return nil, fmt.Errorf("n/a")
+}
+func (f *oidcFakeStore) ListUsers(context.Context, string) ([]api.User, error) { return nil, nil }
+func (f *oidcFakeStore) GetDepartment(context.Context, string) (*api.Department, error) {
+	return nil, fmt.Errorf("n/a")
+}
+func (f *oidcFakeStore) ListDepartments(context.Context) ([]api.Department, error) { return nil, nil }
+func (f *oidcFakeStore) UpdateDepartment(context.Context, *api.Department) error   { return nil }
+func (f *oidcFakeStore) DeleteDepartment(context.Context, string) error            { return nil }
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestSyncOIDCUser_CreateAndResync(t *testing.T) {
+	fs := newOIDCFakeStore()
+	ctx := context.Background()
+	lg := quietLogger()
+
+	// First login: creates the user.
+	if err := syncOIDCUser(ctx, fs, "sub-1", "alice", "alice@corp", "user", "dept-eng", lg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	u := fs.users["sub-1"]
+	if u == nil || u.Provider != "oidc" || u.Role != "user" || u.DepartmentID != "dept-eng" {
+		t.Fatalf("created = %+v", u)
+	}
+	// Second login with promoted role + new email + dept: re-syncs.
+	if err := syncOIDCUser(ctx, fs, "sub-1", "alice", "alice@newcorp", "admin", "dept-plat", lg); err != nil {
+		t.Fatalf("resync: %v", err)
+	}
+	u = fs.users["sub-1"]
+	if u.Role != "admin" || u.Email != "alice@newcorp" || u.DepartmentID != "dept-plat" {
+		t.Errorf("after resync = %+v, want admin/newcorp/plat", u)
+	}
+}
+
+func TestSyncOIDCUser_CrossProviderBindRefused(t *testing.T) {
+	fs := newOIDCFakeStore()
+	ctx := context.Background()
+	// An apikey account whose id collides with an OIDC sub.
+	fs.users["collide"] = &api.User{ID: "collide", Name: "svc", Provider: "local", Status: "active"}
+
+	err := syncOIDCUser(ctx, fs, "collide", "attacker", "", "admin", "", quietLogger())
+	if err == nil {
+		t.Fatal("cross-provider bind was allowed")
+	}
+	// The pre-existing account is untouched.
+	if fs.users["collide"].Provider != "local" || fs.users["collide"].Role == "admin" {
+		t.Errorf("collided account mutated: %+v", fs.users["collide"])
+	}
+}
+
+func TestResolveOIDCDepartment_Deterministic(t *testing.T) {
+	fs := newOIDCFakeStore()
+	ctx := context.Background()
+	claims := map[string]interface{}{"dept": "Platform Eng"}
+
+	id1 := resolveOIDCDepartment(ctx, fs, "dept", claims, quietLogger())
+	id2 := resolveOIDCDepartment(ctx, fs, "dept", claims, quietLogger())
+	if id1 == "" || id1 != id2 {
+		t.Fatalf("non-deterministic dept id: %q vs %q", id1, id2)
+	}
+	if id1 != "dept-platform-eng" {
+		t.Errorf("dept id = %q, want dept-platform-eng", id1)
+	}
+	// Only one department row created despite two resolves.
+	if len(fs.depts) != 1 {
+		t.Errorf("created %d departments, want 1", len(fs.depts))
+	}
+	// Empty claim → no department.
+	if id := resolveOIDCDepartment(ctx, fs, "", claims, quietLogger()); id != "" {
+		t.Errorf("empty claim returned %q", id)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Platform Eng":  "platform-eng",
+		"  R&D / Core ": "r-d-core",
+		"ALL":           "all",
+		"":              "",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/auth/oidc_provision_test.go
+++ b/internal/auth/oidc_provision_test.go
@@ -63,13 +63,17 @@ func (f *oidcFakeStore) GetUserByName(context.Context, string) (*api.User, error
 func (f *oidcFakeStore) GetUserByAPIKeyHash(context.Context, string) (*api.User, error) {
 	return nil, fmt.Errorf("n/a")
 }
-func (f *oidcFakeStore) ListUsers(context.Context, string) ([]api.User, error) { return nil, nil }
+func (f *oidcFakeStore) ListUsers(context.Context, string, int, int) ([]api.User, error) {
+	return nil, nil
+}
 func (f *oidcFakeStore) GetDepartment(context.Context, string) (*api.Department, error) {
 	return nil, fmt.Errorf("n/a")
 }
-func (f *oidcFakeStore) ListDepartments(context.Context) ([]api.Department, error) { return nil, nil }
-func (f *oidcFakeStore) UpdateDepartment(context.Context, *api.Department) error   { return nil }
-func (f *oidcFakeStore) DeleteDepartment(context.Context, string) error            { return nil }
+func (f *oidcFakeStore) ListDepartments(context.Context, int, int) ([]api.Department, error) {
+	return nil, nil
+}
+func (f *oidcFakeStore) UpdateDepartment(context.Context, *api.Department) error { return nil }
+func (f *oidcFakeStore) DeleteDepartment(context.Context, string) error          { return nil }
 
 func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/internal/auth/publicprefix_test.go
+++ b/internal/auth/publicprefix_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSkipAuthPaths_PublicPrefix verifies a module-registered public prefix is
+// exempt from the auth middleware, while protected prefixes still run it.
+func TestSkipAuthPaths_PublicPrefix(t *testing.T) {
+	var authRan bool
+	authMw := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authRan = true
+			next.ServeHTTP(w, r)
+		})
+	}
+	RegisterPublicPrefix("/scim/v2/")
+	h := SkipAuthPaths(authMw)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	cases := []struct {
+		path     string
+		wantAuth bool
+		desc     string
+	}{
+		{"/scim/v2/Users", false, "registered public prefix skips auth"},
+		{"/v1/apps", true, "protected prefix runs auth"},
+		{"/healthz", false, "health is public"},
+	}
+	for _, c := range cases {
+		authRan = false
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", c.path, nil))
+		if authRan != c.wantAuth {
+			t.Errorf("%s: authRan=%v, want %v", c.desc, authRan, c.wantAuth)
+		}
+	}
+}

--- a/internal/httproutes/httproutes.go
+++ b/internal/httproutes/httproutes.go
@@ -19,6 +19,11 @@ import (
 type Route struct {
 	Pattern string // e.g. "POST /v1/rolebindings"
 	Handler http.Handler
+	// Public exempts this route's path from the core's user-auth middleware, so
+	// the module can enforce its own authentication (e.g. a SCIM provisioning
+	// token). The server registers the path as a public prefix; the module's
+	// handler is responsible for authenticating the request itself.
+	Public bool
 }
 
 // Deps is what a route factory receives; Options is a generic settings bag.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -469,7 +470,12 @@ func runHTTPServer(ctx context.Context, cfg *config.Config, mcpServer *mcp.Serve
 	} else {
 		for _, rt := range extraRoutes {
 			mux.Handle(rt.Pattern, rt.Handler)
-			logger.Info("mounted module route", "pattern", rt.Pattern)
+			// A Public route authenticates itself; exempt its path from the core
+			// user-auth middleware. Strip any leading "METHOD " from the pattern.
+			if rt.Public {
+				vibedauth.RegisterPublicPrefix(routePath(rt.Pattern))
+			}
+			logger.Info("mounted module route", "pattern", rt.Pattern, "public", rt.Public)
 		}
 	}
 
@@ -689,6 +695,15 @@ func auditHandler(rec *audit.Recorder, logger *slog.Logger) http.HandlerFunc {
 }
 
 // securityHeadersMiddleware adds standard security headers to all responses.
+// routePath extracts the path from a net/http mux pattern, dropping any leading
+// "METHOD " (e.g. "POST /scim/v2/Users" → "/scim/v2/Users", "/scim/v2/" → same).
+func routePath(pattern string) string {
+	if i := strings.LastIndex(pattern, " "); i >= 0 {
+		return pattern[i+1:]
+	}
+	return pattern
+}
+
 func securityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Frame-Options", "DENY")


### PR DESCRIPTION
## Summary
Lands the second half of the SCIM-support seam work on `main` (the authorizer + HTTP-route seams already merged via #113). This is the content of the previously-stacked #114, rebased onto current `main`.

- **Public HTTP routes** — `httproutes.Route.Public` + `auth.RegisterPublicPrefix` (consulted by `SkipAuthPaths`), so a module can mount a route that authenticates itself (e.g. a SCIM `/scim/v2/` endpoint using its own bearer token) instead of the core user-auth middleware. Needed by the enterprise SCIM API.
- **OIDC provisioning hardening** — parity with the SAML provider: cross-provider bind guard, role/email/department re-sync on each login, deterministic `dept-<slug>` ids (was non-deterministic `dept-%x`). Extracted `syncOIDCUser`/`resolveOIDCDepartment`/`slugify`, unit-tested.
- **Integration fix** — updates the OIDC test's fake store for `main`'s widened `UserStore.ListUsers/ListDepartments` (now paginated).

## Notes
- Clean 3-way merge onto current `main`; full core suite green locally. Suggest **squash-merge** to collapse the internal merge commit.
- After this lands, tag **v0.5.2** so the enterprise module can repin and build against the released seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)