### PR TITLE
docs: correct stale claim-uid references (#42)

### DIFF
--- a/deploy/helm/vibed/templates/controller.yaml
+++ b/deploy/helm/vibed/templates/controller.yaml
@@ -26,7 +26,10 @@ rules:
     resources: ["vibedapps/status"]
     verbs: ["get", "update", "patch"]
   # Services: one per-app ClusterIP Service gives the router a stable upstream
-  # that survives Sandbox pod-IP churn (selects the bound pod by claim-uid).
+  # that survives Sandbox pod-IP churn. It selects the bound pod by the
+  # agents.x-k8s.io/sandbox-name-hash label agent-sandbox v0.5 stamps on it
+  # (the older per-claim agents.x-k8s.io/claim-uid label is filtered off the
+  # adopted warm-pool pod, which caused 502s — see #42).
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -47,11 +47,12 @@ type ServiceManager interface {
 }
 
 // K8sServiceManager ensures one ClusterIP Service per general-lane VibedApp,
-// selecting the bound Sandbox pod via the label selector agent-sandbox
-// publishes on the claim's status.sandbox.selector. The Service gives the
-// router a stable upstream (its cluster-DNS name) that survives Sandbox pod
-// restarts — a raw pod IP goes stale when the pod is recreated with a new IP,
-// leaving Caddy pointed at a dead address (502).
+// selecting the bound Sandbox pod by the agents.x-k8s.io/sandbox-name-hash
+// label agent-sandbox stamps on it (reproduced from the claim's
+// status.sandbox.name — see boundPodSelector). The Service gives the router a
+// stable upstream (its cluster-DNS name) that survives Sandbox pod restarts —
+// a raw pod IP goes stale when the pod is recreated with a new IP, leaving
+// Caddy pointed at a dead address (502).
 //
 // agent-sandbox owns the pod label scheme (v0.5+ tracks pods by
 // agents.x-k8s.io/sandbox-name-hash, replacing the older per-claim label), so


### PR DESCRIPTION
Follow-up to #42 (502 on warm-pool adoption). The functional fix already landed in `7a3e940` — the per-app Service selector moved from `agents.x-k8s.io/claim-uid` (which agent-sandbox v0.5 filters off the adopted warm-pool pod → no endpoints → 502) to `agents.x-k8s.io/sandbox-name-hash`. This just corrects two comments that still described the old scheme and would mislead anyone debugging a #42-style 502:

- `controller.yaml` RBAC comment: "selects the bound pod by claim-uid" → sandbox-name-hash (+ a note about the claim-uid filtering / #42).
- `K8sServiceManager` doc: said it reads `status.sandbox.selector`; the code actually reproduces the `sandbox-name-hash` label from `status.sandbox.name` (`boundPodSelector`).

Comment-only — `helm template` renders and `internal/controller` builds/vets clean.