### PR TITLE
release: v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,81 @@ All notable changes to vibeD are recorded here. The format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); each release is also a signed
 git tag, and the Helm chart's `appVersion` tracks the release.
 
+## v0.5.2 — 2026-07-19
+
+A hardening and team-visibility release. It closes the entire sev-labeled issue
+backlog — performance, correctness, and security fixes across the deploy path,
+controller, quota, rate limiting, and the state stores — adds a pluggable
+authorizer for team-scoped app visibility and SCIM-ready public routes, and
+rolls up the security patch that was staged as v0.5.1 (never tagged).
+
+### Added
+- **Authorizer seam + team visibility**: a per-action `RegisterAuthorizer` seam
+  and an authorizer-scoped app List, so a viewer can see the team's apps rather
+  than only their own; plus an authenticated HTTP-route seam. (#113, #21)
+- **SCIM-ready public HTTP routes** and OIDC provisioning hardening toward SAML
+  parity. (#116, #17)
+- **Rate limiting now covers `/v1/*`** (including the deploy path) with a
+  separate, stricter per-client budget for mutating verbs
+  (`rateLimit.writeRequestsPerSecond` / `rateLimit.writeBurst`); it also warns at
+  startup when disabled on a network transport. (#50)
+- **Global log-stream cap** `limits.maxConcurrentLogStreamsGlobal` alongside the
+  per-user cap. (#81)
+- **List pagination** (`?limit=&offset=`) for the users, departments, and
+  share-link APIs. (#80)
+
+### Changed
+- Helm chart `version` / `appVersion` → **0.5.2**.
+- Auth-disabled mode treats every request as admin, so vibeD now **refuses to
+  start with auth disabled on a non-loopback bind** unless `auth.devInsecure:
+  true` is set (the chart's no-auth path sets it automatically). (#55)
+- `limits.maxConcurrentLogStreamsPerUser` `<=0` now falls back to a safe default
+  instead of meaning unlimited. (#81)
+- Quota counts against the exact `spec.owner`, not a lossy sanitized label, so
+  colliding identities no longer share a quota bucket. (#66)
+
+### Fixed
+- **HTTP 502 on warm-pool adoption**: the per-app Service selected the
+  `agents.x-k8s.io/claim-uid` label that agent-sandbox v0.5 filters off the
+  adopted pod; it now selects `sandbox-name-hash`. (#42)
+- **Dashboard login form** never appeared behind an HTTP/2 gateway (blank
+  `Response.statusText`); the client now branches on the numeric 401. (#41)
+- Quota List-then-Create overshoot under concurrent deploys, closed with an
+  in-process reservation ledger. (#75)
+- The app List and the log-stream pod lookup no longer scan the whole namespace
+  (owner-label pre-filter + a `status.podIP` field selector). (#74, #77)
+
+### Performance
+- O(1) circular log ring buffer, replacing an O(capacity)-per-line shift. (#79)
+- Bounded-sample rate-limiter eviction, replacing an O(n) scan under the write
+  lock. (#62)
+- Controller uses capped exponential backoff for transitional requeues instead
+  of a flat 2s hot-poll. (#70)
+- GC paginates its list sweeps and deletes with bounded concurrency. (#76)
+- Deploy hot path hashes the source during the read pass (one fewer full pass
+  over the up-to-50MB tarball). (#73)
+- SQLite: `created_at` and partial `api_key_hash` indexes, plus an indexed
+  `shared_with` join table replacing a `LIKE` full-table scan. (#80)
+- ConfigMap store: lock-free reads and optimistic-concurrency writes (no
+  process-wide lock held across API I/O), plus a pre-write size guard that fails
+  with an actionable error instead of bricking at etcd's ~1MB ceiling. (#71, #72)
+
+### Security
+- Rolls up the **v0.5.1 security patch**: dependency bumps closing all
+  critical/high advisories (`golang.org/x/crypto`, `x/net`, the npm docs chain,
+  …), CodeQL-flagged hardening (bounded audit allocation, workerd path
+  containment, source-fetch fail-closed), and least-privilege GitHub Actions
+  permissions. (#110)
+- The no-auth startup guard (#55) and stricter deploy-path rate limiting (#50)
+  reduce accidental exposure of an unauthenticated control plane.
+
+### Docs
+- Config reference documents `rateLimit.writeRequestsPerSecond` / `writeBurst`,
+  `limits.maxConcurrentLogStreamsGlobal`, and `auth.devInsecure`; corrects the
+  per-user log-stream `<=0` semantics; and notes the ConfigMap backend's ~1MB
+  scale bound (use `sqlite` at scale).
+- Authentication guide documents the no-auth non-loopback-bind guard.
+
 ## v0.5.0 — 2026-07-09
 
 The `/v1` app data plane reaches parity with the dashboard — version history &

--- a/deploy/helm/vibed/Chart.yaml
+++ b/deploy/helm/vibed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vibed
 description: Workload orchestrator for GenAI-generated artifacts
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.5.2
+appVersion: "0.5.2"
 keywords:
   - mcp
   - genai

--- a/docs/docs/configuration/authentication.md
+++ b/docs/docs/configuration/authentication.md
@@ -14,6 +14,8 @@ MCP clients do not trust unsecured tool servers. Without authentication:
 - Built artifacts and source code could be exposed
 - There is no audit trail of who deployed what
 
+With auth disabled, **every request is treated as admin**. To stop that being exposed by accident, vibeD **refuses to start** when auth is disabled *and* the server binds a non-loopback address, unless you explicitly acknowledge it with `auth.devInsecure: true`. Use that only for local dev or a network-isolated in-cluster listener; the Helm chart's no-auth path sets it for you. The right move for anything reachable by others is to enable auth.
+
 ## Quick Start
 
 The fastest way to enable auth is via a single environment variable:

--- a/docs/docs/configuration/config-reference.md
+++ b/docs/docs/configuration/config-reference.md
@@ -25,10 +25,16 @@ server:
   baseURL: ""                  # public URL for share-link generation
   logFormat: "text"            # text | json
   logLevel: "info"             # debug | info | warn | error
-  rateLimit: { enabled: false, requestsPerSecond: 10, burst: 20 }
+  rateLimit:                   # covers /api, /mcp, and /v1 (incl. the deploy path)
+    enabled: false
+    requestsPerSecond: 10      # steady-state per client (reads)
+    burst: 20
+    writeRequestsPerSecond: 1  # stricter budget for deploy/create/update/delete
+    writeBurst: 5
 
 auth:
   enabled: false               # enable before exposing the API
+  devInsecure: false           # required to run auth-disabled on a non-loopback bind
   mode: "apikey"               # apikey | oauth | oidc
   apiKeys: []                  # see auth section below
   # oidc: { issuer, audience, usernameClaim, roleClaim, adminRole, ... }
@@ -74,7 +80,8 @@ limits:
   maxTotalFileSize: 52428800   # 50 MiB
   maxFileCount: 500
   maxLogLines: 10000
-  maxConcurrentLogStreamsPerUser: 10
+  maxConcurrentLogStreamsPerUser: 10   # <=0 -> safe default (not unlimited)
+  maxConcurrentLogStreamsGlobal: 100   # cap across all users; <=0 -> safe default
 
 quotas:
   enabled: false
@@ -116,17 +123,20 @@ tracing:
 | `baseURL`                      | string  | `""`      | Public-facing base URL used to generate share links, e.g. `http://localhost:8080`. |
 | `logFormat`                    | string  | `text`    | `text` or `json`.                                                                |
 | `logLevel`                     | string  | `info`    | `debug`, `info`, `warn`, or `error`.                                             |
-| `rateLimit.enabled`            | bool    | `false`   | Enable per-client HTTP rate limiting.                                            |
-| `rateLimit.requestsPerSecond`  | float   | `10`      | Steady-state rate per client.                                                    |
-| `rateLimit.burst`              | int     | `20`      | Max burst size per client.                                                       |
+| `rateLimit.enabled`            | bool    | `false`   | Enable per-client HTTP rate limiting. Covers `/api`, `/mcp`, and `/v1` (including the deploy path). Off on a network transport logs a startup warning. |
+| `rateLimit.requestsPerSecond`  | float   | `10`      | Steady-state rate per client for reads.                                          |
+| `rateLimit.burst`              | int     | `20`      | Max burst size per client for reads.                                             |
+| `rateLimit.writeRequestsPerSecond` | float | `1`     | Stricter steady-state rate for mutating verbs (deploy/create/update/delete), so one user can't flood the expensive deploy path. `<=0` → safe default. |
+| `rateLimit.writeBurst`         | int     | `5`       | Max burst for mutating verbs. `<=0` → safe default.                              |
 
 ## `auth`
 
-Governs authentication and TLS termination. When `enabled` is `false` the API is open — enable it before exposing vibeD. See [Authentication](authentication.md) for a full walkthrough.
+Governs authentication and TLS termination. When `enabled` is `false` the API is open (every request is treated as admin) — enable it before exposing vibeD. To guard against that being exposed by accident, vibeD **refuses to start** with auth disabled on a non-loopback bind unless `devInsecure: true` is set. See [Authentication](authentication.md) for a full walkthrough.
 
 | Key       | Type              | Default | Description                                                                             |
 | --------- | ----------------- | ------- | --------------------------------------------------------------------------------------- |
 | `enabled` | bool              | `false` | Turn authentication on.                                                                  |
+| `devInsecure` | bool          | `false` | Acknowledge running with auth disabled on a non-loopback bind. Required to start in that config (otherwise vibeD refuses); intended for local dev or a network-isolated in-cluster listener. The Helm chart's no-auth path sets it automatically. |
 | `mode`    | string            | `""`    | `apikey`, `oauth`, or `oidc`. Out-of-tree providers may register additional modes.      |
 | `apiKeys` | list              | `[]`    | Configured API keys (see below). At least one is required when `mode` is `apikey`/`oauth`/empty. |
 | `oidc`    | object            | —       | OIDC settings (see below).                                                              |
@@ -215,9 +225,9 @@ The state store for control-plane objects (the control plane is stateless; all d
 
 | Key         | Type              | Default  | Description                                                                                  |
 | ----------- | ----------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `backend`   | string            | `sqlite` | `sqlite`, `memory`, or `configmap`. Validated at startup.                                    |
+| `backend`   | string            | `sqlite` | `sqlite` (default, recommended — scales per-row), `memory`, or `configmap`. Validated at startup. |
 | `sqlite`    | object            | —        | `path` (default `/data/vibed.db`). Required when `backend` is `sqlite`.                      |
-| `configmap` | object            | —        | `name` (default `vibed-artifacts`), `namespace` (default `vibed-system`).                   |
+| `configmap` | object            | —        | `name` (default `vibed-artifacts`), `namespace` (default `vibed-system`). Small/dev deployments only — all artifacts share one ConfigMap, bounded by etcd's ~1MB object ceiling; use `sqlite` at scale. |
 | `options`   | map[string]string | `{}`     | Passed verbatim to the backend factory. Core backends ignore it; an out-of-tree backend reads its own settings (DSN, pool size, …) from here, so adding a backend needs no schema change. See [Store backends](../extending/store-backends.md). |
 
 ## `kubernetes`
@@ -236,7 +246,8 @@ Guards on MCP tool inputs and log streaming.
 | `maxTotalFileSize`               | int  | `52428800` | Max total source size per deploy/update, in bytes (50 MiB).                       |
 | `maxFileCount`                   | int  | `500`      | Max number of files per deploy/update.                                           |
 | `maxLogLines`                    | int  | `10000`    | Max log lines returned per request.                                              |
-| `maxConcurrentLogStreamsPerUser` | int  | `10`       | Max simultaneous `/v1/logs` SSE streams per authenticated user. `0` = unlimited. |
+| `maxConcurrentLogStreamsPerUser` | int  | `10`       | Max simultaneous `/v1/logs` SSE streams per authenticated user. `<=0` falls back to a safe default (not unlimited). |
+| `maxConcurrentLogStreamsGlobal`  | int  | `100`      | Max simultaneous `/v1/logs` SSE streams across **all** users, so many users can't collectively exhaust controller memory. `<=0` → safe default. |
 
 ## `quotas`
 

--- a/docs/docs/configuration/custom-base-images.md
+++ b/docs/docs/configuration/custom-base-images.md
@@ -24,7 +24,7 @@ Your image must satisfy the contract below. The simplest path is to start `FROM`
 
 ```dockerfile
 # Stage 1: grab a statically-linked vibed-agent (or COPY one you've vendored).
-FROM ghcr.io/vibed-project/vibed-runner-node:0.5.0 AS agent
+FROM ghcr.io/vibed-project/vibed-runner-node:0.5.2 AS agent
 
 # Stage 2: your hardened base.
 FROM your-registry/hardened-node:24

--- a/docs/docs/deployment/production-guide.md
+++ b/docs/docs/deployment/production-guide.md
@@ -22,9 +22,9 @@ CI builds and pushes all component images to GHCR: `vibed`, `vibed-controller`, 
 ## 2. Production values
 
 ```yaml
-image: { repository: ghcr.io/vibed-project/vibed, tag: "v0.5.0", pullPolicy: IfNotPresent }
-controller: { image: { tag: "v0.5.0" }, domain: apps.example.com }
-router:     { image: { tag: "v0.5.0" } }
+image: { repository: ghcr.io/vibed-project/vibed, tag: "v0.5.2", pullPolicy: IfNotPresent }
+controller: { image: { tag: "v0.5.2" }, domain: apps.example.com }
+router:     { image: { tag: "v0.5.2" } }
 
 # Sandbox isolation
 runtime:

--- a/docs/docs/mcp-tools/list-versions.md
+++ b/docs/docs/mcp-tools/list-versions.md
@@ -30,14 +30,14 @@ List all version snapshots for a deployed artifact, ordered by version number. E
       "version": 1,
       "status": "running",
       "url": "http://my-portfolio.default.localhost:31080",
-      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.5.0",
+      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.5.2",
       "created_at": "2026-03-14T10:00:00Z"
     },
     {
       "version": 2,
       "status": "running",
       "url": "http://my-portfolio.default.localhost:31080",
-      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.5.0",
+      "image_ref": "ghcr.io/vibed-project/vibed-template-static-nginx:0.5.2",
       "created_at": "2026-03-14T12:30:00Z"
     }
   ]

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
           {
             // Current release, shown left of the GitHub link. Bump on release.
             href: 'https://github.com/vibed-project/vibeD/releases',
-            label: 'v0.5.0',
+            label: 'v0.5.2',
             position: 'right',
           },
           {


### PR DESCRIPTION
Cuts **v0.5.2** off `main`. (v0.5.1's security patch was merged but never tagged, so this release rolls it up.)

## Version bumps
- Helm chart `version` / `appVersion` `0.5.0` → `0.5.2` (drives every image tag).
- Docs navbar label and the image-tag examples (production-guide, custom-base-images, list-versions) → `v0.5.2`. The `agent-sandbox v0.5.0+` references and the historical "before v0.5.0 / v0.5.0 API bump" notes are intentionally left as-is.

## Docs brought in sync with everything since v0.5.0
- **config-reference**: documents the new `rateLimit.writeRequestsPerSecond`/`writeBurst` (#50), `limits.maxConcurrentLogStreamsGlobal` (#81), and `auth.devInsecure` (#55); **corrects** the now-wrong `maxConcurrentLogStreamsPerUser` "`0` = unlimited" (it's a safe default now, #81); notes the ConfigMap backend's ~1MB scale bound (#71).
- **authentication**: documents the no-auth non-loopback-bind startup guard (#55).
- **CHANGELOG**: full `v0.5.2` entry (sev sweep #112, authorizer #113, SCIM public routes/OIDC #116, #41 login fix, #42 warm-pool 502, and the rolled-up v0.5.1 security patch #110).

README was reviewed — no correction needed (its `agent-sandbox v0.5.0+` note is still accurate; the config snippet links to the full reference).

## Validation
- [x] `helm template` renders at 0.5.2
- [x] `docs` (Docusaurus) builds clean — no broken links/MDX

## Release steps after merge
1. Merge this PR.
2. Tag `v0.5.2` on the merge commit + push.
3. Publish the GitHub Release from the tag (notes = the CHANGELOG v0.5.2 section).

I've prepared the tag + release-notes text and will apply them once this is merged (or you can) — I'm not pushing the tag against an unmerged branch.